### PR TITLE
Update AEAD crypter interface

### DIFF
--- a/security/s2a/internal/crypter/aeadcrypter.go
+++ b/security/s2a/internal/crypter/aeadcrypter.go
@@ -5,10 +5,10 @@ package crypter
 type S2AAeadCrypter interface {
 	// Encrypt encrypts the plaintext and computes the tag of dst and plaintext.
 	// dst and plaintext may fully overlap or not at all.
-	Encrypt(dst, plaintext []byte) ([]byte, error)
+	Encrypt(dst, plaintext, nonce, aad []byte) ([]byte, error)
 	// Decrypt decrypts ciphertext and verifies the tag. dst and ciphertext may
 	// fully overlap or not at all.
-	Decrypt(dst, ciphertext []byte) ([]byte, error)
+	Decrypt(dst, ciphertext, nonce, aad []byte) ([]byte, error)
 	// TagSize returns the tag size in bytes.
 	TagSize() int
 	// UpdateKey updates the key used for encryption and decryption.


### PR DESCRIPTION
Updated the S2A AEAD crypter interface to include `nonce` and `aad`. These are fields which are not present in ALTS, but required in S2A.