### PR TITLE
Unexport AEAD crypter interface

### DIFF
--- a/security/s2a/internal/crypter/aeadcrypter.go
+++ b/security/s2a/internal/crypter/aeadcrypter.go
@@ -1,16 +1,16 @@
 package crypter
 
-// S2AAeadCrypter is the interface for an AEAD cipher used by the S2A record
+// s2aAeadCrypter is the interface for an AEAD cipher used by the S2A record
 // protocol.
-type S2AAeadCrypter interface {
-	// Encrypt encrypts the plaintext and computes the tag of dst and plaintext.
+type s2aAeadCrypter interface {
+	// encrypt encrypts the plaintext and computes the tag of dst and plaintext.
 	// dst and plaintext may fully overlap or not at all.
-	Encrypt(dst, plaintext, nonce, aad []byte) ([]byte, error)
-	// Decrypt decrypts ciphertext and verifies the tag. dst and ciphertext may
+	encrypt(dst, plaintext, nonce, aad []byte) ([]byte, error)
+	// decrypt decrypts ciphertext and verifies the tag. dst and ciphertext may
 	// fully overlap or not at all.
-	Decrypt(dst, ciphertext, nonce, aad []byte) ([]byte, error)
-	// TagSize returns the tag size in bytes.
-	TagSize() int
-	// UpdateKey updates the key used for encryption and decryption.
-	UpdateKey(key []byte) error
+	decrypt(dst, ciphertext, nonce, aad []byte) ([]byte, error)
+	// tagSize returns the tag size in bytes.
+	tagSize() int
+	// updateKey updates the key used for encryption and decryption.
+	updateKey(key []byte) error
 }

--- a/security/s2a/internal/crypter/common.go
+++ b/security/s2a/internal/crypter/common.go
@@ -9,11 +9,11 @@ const (
 	nonceSize = 12
 )
 
-// SliceForAppend takes a slice and a requested number of bytes. It returns a
+// sliceForAppend takes a slice and a requested number of bytes. It returns a
 // slice with the contents of the given slice followed by that many bytes and a
 // second slice that aliases into it and contains only the extra bytes. If the
 // original slice has sufficient capacity then no allocation is performed.
-func SliceForAppend(in []byte, n int) (head, tail []byte) {
+func sliceForAppend(in []byte, n int) (head, tail []byte) {
 	if total := len(in) + n; cap(in) >= total {
 		head = in[:total]
 	} else {

--- a/security/s2a/internal/crypter/testutil/common.go
+++ b/security/s2a/internal/crypter/testutil/common.go
@@ -10,7 +10,7 @@ const (
 	InvalidResult = "invalid"
 )
 
-// CryptoTestVector is a struct representing a test vector for an S2AAeadCrypter
+// CryptoTestVector is a struct representing a test vector for an s2aAeadCrypter
 // instance.
 type CryptoTestVector struct {
 	ID                                          int


### PR DESCRIPTION
Unexported the AEAD crypter interface, since it will not be used outside of the `crypter` package.