### PR TITLE
Add S2A Half Connection Counter class

### DIFF
--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -4,7 +4,7 @@ import "errors"
 
 // counter is a 64-bit counter.
 type counter struct {
-	value         uint64
+	val           uint64
 	hasOverflowed bool
 }
 
@@ -12,23 +12,23 @@ func newCounter() counter {
 	return counter{}
 }
 
-// val returns the current value of the counter.
-func (c *counter) val() (uint64, error) {
+// value returns the current value of the counter.
+func (c *counter) value() (uint64, error) {
 	if c.hasOverflowed {
 		return 0, errors.New("counter has overflowed")
 	}
-	return c.value, nil
+	return c.val, nil
 }
 
-// inc increments the counter and checks for overflow.
-func (c *counter) inc() {
+// increment increments the counter and checks for overflow.
+func (c *counter) increment() {
 	// If the counter is already invalid due to overflow, there is no need to
-	// increase it. We check for the hasOverflowed flag in the call to val().
+	// increase it. We check for the hasOverflowed flag in the call to value().
 	if c.hasOverflowed {
 		return
 	}
-	c.value++
-	if c.value == 0 {
+	c.val++
+	if c.val == 0 {
 		c.hasOverflowed = true
 	}
 }
@@ -36,6 +36,6 @@ func (c *counter) inc() {
 // reset sets the counter value to zero and sets the hasOverflowed flag to
 // false.
 func (c *counter) reset() {
-	c.value = 0
+	c.val = 0
 	c.hasOverflowed = false
 }

--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -1,0 +1,42 @@
+package crypter
+
+import "errors"
+
+const counterLen = 12
+
+// counter is a 96-bit, little-endian counter.
+type counter struct {
+	value   [counterLen]byte
+	invalid bool
+}
+
+func newCounter() counter {
+	return counter{}
+}
+
+// val returns the current value of the counter as a byte slice.
+func (c *counter) val() ([]byte, error) {
+	if c.invalid {
+		return nil, errors.New("invalid counter, possibly due to overflow")
+	}
+	return c.value[:], nil
+}
+
+// inc increments the counter and checks for overflow.
+func (c *counter) inc() {
+	// If the counter is already invalid, there is no need to increase it. We
+	// check for the invalid flag in the call to val().
+	if c.invalid {
+		return
+	}
+	i := 0
+	for ; i < counterLen; i++ {
+		c.value[i]++
+		if c.value[i] != 0 {
+			break
+		}
+	}
+	if i == counterLen {
+		c.invalid = true
+	}
+}

--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -1,7 +1,6 @@
 package crypter
 
 import (
-	"encoding/binary"
 	"errors"
 )
 
@@ -18,19 +17,17 @@ func newCounter(value uint64) counter {
 	return counter{value: value}
 }
 
-// getAndIncrement returns the current value of the counter as a byte slice,
-// and increments the underlying value.
-func (c *counter) getAndIncrement() ([]byte, error) {
+// getAndIncrement returns the current value of the counter and increments it.
+func (c *counter) getAndIncrement() (uint64, error) {
 	if c.hasOverflowed {
-		return nil, errors.New("invalid counter due to overflow")
+		return 0, errors.New("invalid counter due to overflow")
 	}
-	buf := make([]byte, counterLen)
-	binary.LittleEndian.PutUint64(buf, c.value)
+	val := c.value
 	c.value++
 	if c.value == 0 {
 		c.hasOverflowed = true
 	}
-	return buf, nil
+	return val, nil
 }
 
 // reset sets the counter value to zero and sets hasOverflowed to false.

--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -1,8 +1,6 @@
 package crypter
 
-import (
-	"errors"
-)
+import "errors"
 
 // counter is a 64-bit counter.
 type counter struct {
@@ -10,24 +8,33 @@ type counter struct {
 	hasOverflowed bool
 }
 
-func newCounter(value uint64) counter {
-	return counter{value: value}
+func newCounter() counter {
+	return counter{}
 }
 
-// getAndIncrement returns the current value of the counter and increments it.
-func (c *counter) getAndIncrement() (uint64, error) {
+// val returns the current value of the counter.
+func (c *counter) val() (uint64, error) {
 	if c.hasOverflowed {
 		return 0, errors.New("counter has overflowed")
 	}
-	val := c.value
+	return c.value, nil
+}
+
+// inc increments the counter and checks for overflow.
+func (c *counter) inc() {
+	// If the counter is already invalid due to overflow, there is no need to
+	// increase it. We check for the hasOverflowed flag in the call to val().
+	if c.hasOverflowed {
+		return
+	}
 	c.value++
 	if c.value == 0 {
 		c.hasOverflowed = true
 	}
-	return val, nil
 }
 
-// reset sets the counter value to zero and sets hasOverflowed to false.
+// reset sets the counter value to zero and sets the hasOverflowed flag to
+// false.
 func (c *counter) reset() {
 	c.value = 0
 	c.hasOverflowed = false

--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -18,30 +18,22 @@ func newCounter(value uint64) counter {
 	return counter{value: value}
 }
 
-// val returns the current value of the counter as a byte slice.
-func (c *counter) val() ([]byte, error) {
+// getAndIncrement returns the current value of the counter as a byte slice,
+// and increments the underlying value.
+func (c *counter) getAndIncrement() ([]byte, error) {
 	if c.hasOverflowed {
 		return nil, errors.New("invalid counter due to overflow")
 	}
 	buf := make([]byte, counterLen)
 	binary.LittleEndian.PutUint64(buf, c.value)
-	return buf, nil
-}
-
-// inc increments the counter and checks for overflow.
-func (c *counter) inc() {
-	// If the counter is already invalid due to overflow, there is no need to
-	// increase it. We check for the hasOverflowed flag in the call to val().
-	if c.hasOverflowed {
-		return
-	}
 	c.value++
 	if c.value == 0 {
 		c.hasOverflowed = true
 	}
+	return buf, nil
 }
 
-// reset sets the counter value to zero and resets the hasOverflowed flag.
+// reset sets the counter value to zero and sets hasOverflowed to false.
 func (c *counter) reset() {
 	c.value = 0
 	c.hasOverflowed = false

--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -4,10 +4,7 @@ import (
 	"errors"
 )
 
-// counterLen is the byte length of the counter.
-const counterLen = 8
-
-// counter is a 64-bit, little-endian counter.
+// counter is a 64-bit counter.
 type counter struct {
 	value         uint64
 	hasOverflowed bool
@@ -20,7 +17,7 @@ func newCounter(value uint64) counter {
 // getAndIncrement returns the current value of the counter and increments it.
 func (c *counter) getAndIncrement() (uint64, error) {
 	if c.hasOverflowed {
-		return 0, errors.New("invalid counter due to overflow")
+		return 0, errors.New("counter has overflowed")
 	}
 	val := c.value
 	c.value++

--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -40,3 +40,9 @@ func (c *counter) inc() {
 		c.hasOverflowed = true
 	}
 }
+
+// reset sets the counter value to zero and resets the hasOverflowed flag.
+func (c *counter) reset() {
+	c.value = 0
+	c.hasOverflowed = false
+}

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -24,7 +24,7 @@ func TestCounterInc(t *testing.T) {
 			expectedCounter: 124,
 		},
 		{
-			desc:            "max overflow",
+			desc:            "almost overflow",
 			counter:         math.MaxUint64 - 1,
 			expectedCounter: math.MaxUint64,
 		},
@@ -34,44 +34,46 @@ func TestCounterInc(t *testing.T) {
 			overflow: true,
 		},
 	} {
-		// Make first getAndIncrement call. This should return the same value
-		// which was given.
-		c := newCounter(test.counter)
-		value, err := c.getAndIncrement()
-		if err != nil {
-			t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
-		}
-		if value != test.counter {
-			t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.counter)
-		}
-		if test.overflow {
-			if !c.hasOverflowed {
-				t.Errorf("counter(%v).getAndIncrement() did not set hasOverflowed flag", test.counter)
-			}
-		} else {
-			if c.hasOverflowed {
-				t.Errorf("counter(%v).getAndIncrement() unexpectedly set hasOverflowed flag", test.counter)
-			}
-		}
-
-		// Make second getAndIncrement call. This should verify that the first
-		// getAndIncrement call succeeded in incrementing the value.
-		value, err = c.getAndIncrement()
-		if test.overflow {
-			if err == nil {
-				t.Errorf("counter(%v).getAndIncrement() expected error, received none", test.counter)
-			}
-			if !c.hasOverflowed {
-				t.Errorf("counter(%v).getAndIncrement() did not set hasOverflowed flag", test.counter)
-			}
-		} else {
+		t.Run(test.desc, func(t *testing.T) {
+			// Make first getAndIncrement call. This should return the same value
+			// which was given.
+			c := newCounter(test.counter)
+			value, err := c.getAndIncrement()
 			if err != nil {
 				t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
 			}
-			if value != test.expectedCounter {
-				t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.expectedCounter)
+			if value != test.counter {
+				t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.counter)
 			}
-		}
+			if test.overflow {
+				if !c.hasOverflowed {
+					t.Errorf("counter(%v).getAndIncrement() did not set hasOverflowed flag", test.counter)
+				}
+			} else {
+				if c.hasOverflowed {
+					t.Errorf("counter(%v).getAndIncrement() unexpectedly set hasOverflowed flag", test.counter)
+				}
+			}
+
+			// Make second getAndIncrement call. This should verify that the first
+			// getAndIncrement call succeeded in incrementing the value.
+			value, err = c.getAndIncrement()
+			if test.overflow {
+				if err == nil {
+					t.Errorf("counter(%v).getAndIncrement() expected error, received none", test.counter)
+				}
+				if !c.hasOverflowed {
+					t.Errorf("counter(%v).getAndIncrement() did not set hasOverflowed flag", test.counter)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
+				}
+				if value != test.expectedCounter {
+					t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.expectedCounter)
+				}
+			}
+		})
 	}
 }
 
@@ -86,20 +88,22 @@ func TestCounterReset(t *testing.T) {
 			counter: math.MaxUint64,
 		},
 	} {
-		c := newCounter(test.counter)
-		_, err := c.getAndIncrement()
-		if err != nil {
-			t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
-		}
+		t.Run(test.desc, func(t *testing.T) {
+			c := newCounter(test.counter)
+			_, err := c.getAndIncrement()
+			if err != nil {
+				t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
+			}
 
-		// Check that resetting the counter works as expected.
-		c.reset()
-		value, err := c.getAndIncrement()
-		if err != nil {
-			t.Errorf("counter returned an error after resetting: %v", err)
-		}
-		if value != 0 {
-			t.Errorf("counter(%v).reset().getAndIncrement() = %v, expected 0", test.counter, err)
-		}
+			// Check that resetting the counter works as expected.
+			c.reset()
+			value, err := c.getAndIncrement()
+			if err != nil {
+				t.Errorf("counter returned an error after resetting: %v", err)
+			}
+			if value != 0 {
+				t.Errorf("counter(%v).reset().getAndIncrement() = %v, expected 0", test.counter, value)
+			}
+		})
 	}
 }

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -72,5 +72,15 @@ func TestCounterInc(t *testing.T) {
 				t.Errorf("counter(%v).val() unexpectedly set hasOverflowed flag", test.counter)
 			}
 		}
+
+		// Check that resetting the counter works as expected.
+		c.reset()
+		value, err = c.val()
+		if err != nil {
+			t.Errorf("counter returned an error after resetting: %v", err)
+		}
+		if binary.LittleEndian.Uint64(value) != 0 {
+			t.Errorf("counter(%v).reset.val() = %v, expected 0", test.counter, err)
+		}
 	}
 }

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -1,0 +1,76 @@
+package crypter
+
+import (
+	"bytes"
+	"google.golang.org/grpc/security/s2a/internal/crypter/testutil"
+	"testing"
+)
+
+// counterFromValue creates a new counter given an initial value.
+func counterFromValue(value []byte) (c counter) {
+	copy(c.value[:], value)
+	return
+}
+
+func TestCounterInc(t *testing.T) {
+	for _, test := range []struct {
+		desc          string
+		counter, want []byte
+		overflow      bool
+	}{
+		{
+			desc:    "basic 1",
+			counter: testutil.Dehex("000000000000000000000000"),
+			want:    testutil.Dehex("010000000000000000000000"),
+		},
+		{
+			desc:    "basic 2",
+			counter: testutil.Dehex("000000000000000000000080"),
+			want:    testutil.Dehex("010000000000000000000080"),
+		},
+		{
+			desc:    "basic 3",
+			counter: testutil.Dehex("42ff00000000000000000000"),
+			want:    testutil.Dehex("43ff00000000000000000000"),
+		},
+		{
+			desc:    "hex overflow 1",
+			counter: testutil.Dehex("ff0000000000000000000000"),
+			want:    testutil.Dehex("000100000000000000000000"),
+		},
+		{
+			desc:    "hex overflow 2",
+			counter: testutil.Dehex("ffffffff0000000000000000"),
+			want:    testutil.Dehex("000000000100000000000000"),
+		},
+		{
+			desc:    "hex overflow 3",
+			counter: testutil.Dehex("ffffffff0000000000000080"),
+			want:    testutil.Dehex("000000000100000000000080"),
+		},
+		{
+			desc:     "max overflow",
+			counter:  testutil.Dehex("ffffffffffffffffffffffff"),
+			overflow: true,
+		},
+	} {
+		c := counterFromValue(test.counter)
+		c.inc()
+		value, err := c.val()
+		if test.overflow {
+			if err == nil {
+				t.Errorf("counter(%v).val() expected error, received none", test.counter)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("counter(%v).val() returned error: %v", test.counter, err)
+			}
+			if !bytes.Equal(value, test.want) {
+				t.Errorf("counter(%v).val() = %v, want %v", test.counter, value, test.want)
+			}
+			if c.invalid {
+				t.Errorf("counter(%v).val() unexpectedly set invalid flag", test.counter)
+			}
+		}
+	}
+}

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -33,9 +33,9 @@ func TestCounterInc(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			c := counter{value: tc.counter}
-			c.inc()
-			val, err := c.val()
+			c := counter{val: tc.counter}
+			c.increment()
+			val, err := c.value()
 			if got, want := err == nil, !tc.shouldOverflow; got != want {
 				t.Errorf("counter starting with %v, val()=(err=nil)=%v, want %v", tc.counter, got, want)
 			}
@@ -79,7 +79,7 @@ func TestCounterReset(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			c := counter{tc.counter, tc.hasOverflowed}
 			c.reset()
-			if got, want := c.value, uint64(0); got != want {
+			if got, want := c.val, uint64(0); got != want {
 				t.Errorf("counter with value %v, c.value = %v, want %v", tc.counter, got, want)
 			}
 			if got, want := c.hasOverflowed, false; got != want {

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -12,12 +12,14 @@ func counterFromValue(value []byte) (c counter) {
 	return newCounter(binary.LittleEndian.Uint64(value))
 }
 
+type counterTest struct {
+	desc          string
+	counter, want []byte
+	overflow      bool
+}
+
 func TestCounterInc(t *testing.T) {
-	for _, test := range []struct {
-		desc          string
-		counter, want []byte
-		overflow      bool
-	}{
+	for _, test := range []counterTest{
 		{
 			desc:    "basic 1",
 			counter: testutil.Dehex("0000000000000000"),
@@ -54,33 +56,63 @@ func TestCounterInc(t *testing.T) {
 			overflow: true,
 		},
 	} {
+		// Test first getAndIncrement call. This should return the same value
+		// which was given.
 		c := counterFromValue(test.counter)
-		c.inc()
-		value, err := c.val()
+		value, err := c.getAndIncrement()
+		if err != nil {
+			t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
+		}
+		if !bytes.Equal(value, test.counter) {
+			t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.counter)
+		}
+
+		// Test second getAndIncrement call. This should verify that the first
+		// getAndIncrement call succeeded in incrementing the value.
+		value, err = c.getAndIncrement()
 		if test.overflow {
 			if err == nil {
-				t.Errorf("counter(%v).val() expected error, received none", test.counter)
+				t.Errorf("counter(%v).getAndIncrement() expected error, received none", test.counter)
 			}
 		} else {
 			if err != nil {
-				t.Errorf("counter(%v).val() returned error: %v", test.counter, err)
+				t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
 			}
 			if !bytes.Equal(value, test.want) {
-				t.Errorf("counter(%v).val() = %v, want %v", test.counter, value, test.want)
+				t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.want)
 			}
 			if c.hasOverflowed {
-				t.Errorf("counter(%v).val() unexpectedly set hasOverflowed flag", test.counter)
+				t.Errorf("counter(%v).getAndIncrement() unexpectedly set hasOverflowed flag", test.counter)
 			}
+		}
+	}
+}
+
+func TestCounterReset(t *testing.T) {
+	for _, test := range []counterTest{
+		{
+			desc:    "basic reset",
+			counter: testutil.Dehex("0100000000000000"),
+		},
+		{
+			desc:    "reset after overflow",
+			counter: testutil.Dehex("ffffffffffffffff"),
+		},
+	} {
+		c := counterFromValue(test.counter)
+		_, err := c.getAndIncrement()
+		if err != nil {
+			t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
 		}
 
 		// Check that resetting the counter works as expected.
 		c.reset()
-		value, err = c.val()
+		value, err := c.getAndIncrement()
 		if err != nil {
 			t.Errorf("counter returned an error after resetting: %v", err)
 		}
 		if binary.LittleEndian.Uint64(value) != 0 {
-			t.Errorf("counter(%v).reset.val() = %v, expected 0", test.counter, err)
+			t.Errorf("counter(%v).reset.getAndIncrement() = %v, expected 0", test.counter, err)
 		}
 	}
 }

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -5,13 +5,6 @@ import (
 	"testing"
 )
 
-// counterFromValue creates a new counter given an initial value.
-func counterFromValue(value uint64) counter {
-	c := newCounter()
-	c.value = value
-	return c
-}
-
 func TestCounterInc(t *testing.T) {
 	for _, tc := range []struct {
 		desc                     string
@@ -40,7 +33,7 @@ func TestCounterInc(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			c := counterFromValue(tc.counter)
+			c := counter{value: tc.counter}
 			c.inc()
 			val, err := c.val()
 			if tc.overflow {

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -6,22 +6,27 @@ import (
 )
 
 type counterTest struct {
-	desc          string
-	counter, want uint64
-	overflow      bool
+	desc                     string
+	counter, expectedCounter uint64
+	overflow                 bool
 }
 
 func TestCounterInc(t *testing.T) {
 	for _, test := range []counterTest{
 		{
-			desc:    "basic 1",
-			counter: 0,
-			want:    1,
+			desc:            "basic 1",
+			counter:         0,
+			expectedCounter: 1,
 		},
 		{
-			desc:    "basic 2",
-			counter: 123,
-			want:    124,
+			desc:            "basic 2",
+			counter:         123,
+			expectedCounter: 124,
+		},
+		{
+			desc:            "max overflow",
+			counter:         math.MaxUint64 - 1,
+			expectedCounter: math.MaxUint64,
 		},
 		{
 			desc:     "max overflow",
@@ -29,7 +34,7 @@ func TestCounterInc(t *testing.T) {
 			overflow: true,
 		},
 	} {
-		// Test first getAndIncrement call. This should return the same value
+		// Make first getAndIncrement call. This should return the same value
 		// which was given.
 		c := newCounter(test.counter)
 		value, err := c.getAndIncrement()
@@ -39,23 +44,32 @@ func TestCounterInc(t *testing.T) {
 		if value != test.counter {
 			t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.counter)
 		}
+		if test.overflow {
+			if !c.hasOverflowed {
+				t.Errorf("counter(%v).getAndIncrement() did not set hasOverflowed flag", test.counter)
+			}
+		} else {
+			if c.hasOverflowed {
+				t.Errorf("counter(%v).getAndIncrement() unexpectedly set hasOverflowed flag", test.counter)
+			}
+		}
 
-		// Test second getAndIncrement call. This should verify that the first
+		// Make second getAndIncrement call. This should verify that the first
 		// getAndIncrement call succeeded in incrementing the value.
 		value, err = c.getAndIncrement()
 		if test.overflow {
 			if err == nil {
 				t.Errorf("counter(%v).getAndIncrement() expected error, received none", test.counter)
 			}
+			if !c.hasOverflowed {
+				t.Errorf("counter(%v).getAndIncrement() did not set hasOverflowed flag", test.counter)
+			}
 		} else {
 			if err != nil {
 				t.Errorf("counter(%v).getAndIncrement() returned error: %v", test.counter, err)
 			}
-			if value != test.want {
-				t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.want)
-			}
-			if c.hasOverflowed {
-				t.Errorf("counter(%v).getAndIncrement() unexpectedly set hasOverflowed flag", test.counter)
+			if value != test.expectedCounter {
+				t.Errorf("counter(%v).getAndIncrement() = %v, want %v", test.counter, value, test.expectedCounter)
 			}
 		}
 	}


### PR DESCRIPTION
Added a Counter class for the S2A Half Connection. This will be used in the half connection to keep track of the sequence number which is used as part of the nonce. 

I took the approach of using a byte slice rather than using an integer and converting it to a byte array on the fly whenever `val()` is called. This (using a byte slice) is what is done in ALTS - I'm not sure what the performance differences are but I suspect that this is slightly more efficient than converting an integer on the fly.

Also, I chose to return an error on calling `val` rather than on calling `inc` in case of an overflow, but happy to change that if anyone has other thoughts.