### PR TITLE
Add S2A Half Connection

### DIFF
--- a/security/s2a/internal/crypter/common.go
+++ b/security/s2a/internal/crypter/common.go
@@ -12,9 +12,9 @@ const (
 	// nonceSize is the size of the nonce in number of bytes for
 	// AES-128-GCM-SHA256, AES-256-GCM-SHA384, and CHACHA20-POLY1305-SHA256.
 	nonceSize = 12
-	// sha256DigestSize is the digest length of sha256 in bytes.
+	// sha256DigestSize is the digest size of sha256 in bytes.
 	sha256DigestSize = 32
-	// sha384DigestSize is the digest length of sha384 in bytes.
+	// sha384DigestSize is the digest size of sha384 in bytes.
 	sha384DigestSize = 48
 )
 

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -8,13 +8,16 @@ import (
 	"sync"
 )
 
+// uint64Size is the size of a uint64 in bytes.
+const uint64Size = 8
+
 const (
 	tls13Key    = "tls13 key"
 	tls13Nonce  = "tls13 iv"
-	tls13Update = "tls13 upd"
+	tls13Update = "tls13 traffic upd"
 )
 
-type s2aHalfConnection struct {
+type S2AHalfConnection struct {
 	cs            ciphersuite
 	h             func() hash.Hash
 	aeadCrypter   s2aAeadCrypter
@@ -23,36 +26,35 @@ type s2aHalfConnection struct {
 	mutex         sync.Mutex
 	trafficSecret []byte
 	nonce         []byte
+	key           []byte
 }
 
-func newHalfConn(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte) (s2aHalfConnection, error) {
+// NewHalfConn creates a new instance of S2AHalfConnection.
+func NewHalfConn(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte) (S2AHalfConnection, error) {
 	cs := newCiphersuite(ciphersuite)
 	if cs.trafficSecretSize() != len(trafficSecret) {
-		return s2aHalfConnection{}, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v", cs.trafficSecretSize(), trafficSecret)
+		return S2AHalfConnection{}, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v", cs.trafficSecretSize(), trafficSecret)
 	}
 
-	hc := s2aHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, seqCounter: newCounter()}
+	hc := S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, seqCounter: newCounter(), trafficSecret: trafficSecret}
 
-	key, err := hc.deriveSecret(trafficSecret, []byte(tls13Key), hc.cs.keySize())
-	if err != nil {
-		return s2aHalfConnection{}, fmt.Errorf("hc.deriveSecret(h, %v, %v, %v) failed with error: %v", trafficSecret, tls13Key, hc.cs.keySize(), err)
+	var err error
+	if err = hc.updateWithNewTrafficSecret(hc.trafficSecret); err != nil {
+		return S2AHalfConnection{}, fmt.Errorf("hc.updateWithNewTrafficSecret(%v) failed with error: %v", hc.trafficSecret, err)
 	}
 
-	hc.nonce, err = hc.deriveSecret(trafficSecret, []byte(tls13Nonce), hc.cs.nonceSize())
+	hc.aeadCrypter, err = cs.aeadCrypter(hc.key)
 	if err != nil {
-		return s2aHalfConnection{}, fmt.Errorf("hc.deriveSecret(h, %v, %v, %v) failed with error: %v", trafficSecret, tls13Nonce, hc.cs.nonceSize(), err)
-	}
-
-	hc.aeadCrypter, err = cs.aeadCrypter(key)
-	if err != nil {
-		return s2aHalfConnection{}, fmt.Errorf("cs.aeadCrypter(%v) failed with error: %v", key, err)
+		return S2AHalfConnection{}, fmt.Errorf("cs.aeadCrypter(%v) failed with error: %v", hc.key, err)
 	}
 	return hc, nil
 }
 
-// encrypt encrypts the plaintext and computes the tag of dst and plaintext.
-// dst and plaintext may fully overlap or not at all.
-func (hc *s2aHalfConnection) encrypt(dst, plaintext, aad []byte) ([]byte, error) {
+// Encrypt encrypts the plaintext and computes the tag of dst and plaintext.
+// dst and plaintext may fully overlap or not at all. Note that the sequence
+// number will still be incremented on failure, unless the sequence has
+// overflowed.
+func (hc *S2AHalfConnection) Encrypt(dst, plaintext, aad []byte) ([]byte, error) {
 	hc.mutex.Lock()
 	sequence, err := hc.getAndIncrementSequence()
 	if err != nil {
@@ -65,9 +67,10 @@ func (hc *s2aHalfConnection) encrypt(dst, plaintext, aad []byte) ([]byte, error)
 	return crypter.encrypt(dst, plaintext, nonce, aad)
 }
 
-// decrypt decrypts ciphertext and verifies the tag. dst and ciphertext may
-// fully overlap or not at all.
-func (hc *s2aHalfConnection) decrypt(dst, ciphertext, aad []byte) ([]byte, error) {
+// Decrypt decrypts ciphertext and verifies the tag. dst and ciphertext may
+// fully overlap or not at all. Note that the sequence number will still be
+// incremented on failure, unless the sequence has overflowed.
+func (hc *S2AHalfConnection) Decrypt(dst, ciphertext, aad []byte) ([]byte, error) {
 	hc.mutex.Lock()
 	sequence, err := hc.getAndIncrementSequence()
 	if err != nil {
@@ -80,9 +83,9 @@ func (hc *s2aHalfConnection) decrypt(dst, ciphertext, aad []byte) ([]byte, error
 	return crypter.decrypt(dst, ciphertext, nonce, aad)
 }
 
-// updateKey updates the traffic secret key, as specified in
+// UpdateKey updates the traffic secret key, as specified in
 // https://tools.ietf.org/html/rfc8446#section-7.2
-func (hc *s2aHalfConnection) updateKey() error {
+func (hc *S2AHalfConnection) UpdateKey() error {
 	hc.mutex.Lock()
 	defer hc.mutex.Unlock()
 
@@ -92,26 +95,37 @@ func (hc *s2aHalfConnection) updateKey() error {
 		return fmt.Errorf("hc.deriveSecret(h, %v, %v, %v) failed with error: %v", hc.trafficSecret, tls13Update, hc.cs.trafficSecretSize(), err)
 	}
 
-	key, err := hc.deriveSecret(hc.trafficSecret, []byte(tls13Key), hc.cs.keySize())
-	if err != nil {
-		return fmt.Errorf("hc.deriveSecret(h, %v, %v, %v) failed with error: %v", hc.trafficSecret, tls13Key, hc.cs.keySize(), err)
+	if err = hc.updateWithNewTrafficSecret(hc.trafficSecret); err != nil {
+		return fmt.Errorf("hc.updateWithNewTrafficSecret(%v) failed with error: %v", hc.trafficSecret, err)
 	}
 
-	hc.nonce, err = hc.deriveSecret(hc.trafficSecret, []byte(tls13Nonce), hc.cs.nonceSize())
+	err = hc.aeadCrypter.updateKey(hc.key)
 	if err != nil {
-		return fmt.Errorf("hc.deriveSecret(h, %v, %v, %v) failed with error: %v", hc.trafficSecret, tls13Nonce, hc.cs.nonceSize(), err)
-	}
-
-	err = hc.aeadCrypter.updateKey(key)
-	if err != nil {
-		return fmt.Errorf("hc.aeadCrypter.updateKey(%v) failed with error: %v", key, err)
+		return fmt.Errorf("hc.aeadCrypter.updateKey(%v) failed with error: %v", hc.key, err)
 	}
 
 	hc.seqCounter.reset()
 	return nil
 }
 
-func (hc *s2aHalfConnection) getAndIncrementSequence() (uint64, error) {
+// updateWithNewTrafficSecret takes a new traffic secret and updates the key
+// and nonce.
+func (hc *S2AHalfConnection) updateWithNewTrafficSecret(newTrafficSecret []byte) error {
+	var err error
+	hc.key, err = hc.deriveSecret(newTrafficSecret, []byte(tls13Key), hc.cs.keySize())
+	if err != nil {
+		return fmt.Errorf("hc.deriveSecret(h, %v, %v, %v) failed with error: %v", hc.trafficSecret, tls13Key, hc.cs.keySize(), err)
+	}
+
+	hc.nonce, err = hc.deriveSecret(newTrafficSecret, []byte(tls13Nonce), hc.cs.nonceSize())
+	if err != nil {
+		return fmt.Errorf("hc.deriveSecret(h, %v, %v, %v) failed with error: %v", hc.trafficSecret, tls13Nonce, hc.cs.nonceSize(), err)
+	}
+	return nil
+}
+
+// getAndIncrement returns the current sequence number and increments it.
+func (hc *S2AHalfConnection) getAndIncrementSequence() (uint64, error) {
 	sequence, err := hc.seqCounter.value()
 	if err != nil {
 		return 0, err
@@ -120,23 +134,28 @@ func (hc *s2aHalfConnection) getAndIncrementSequence() (uint64, error) {
 	return sequence, nil
 }
 
-func (hc *s2aHalfConnection) maskedNonce(sequence uint64) []byte {
+// maskedNonce creates a new S2A nonce using the sequence number.
+func (hc *S2AHalfConnection) maskedNonce(sequence uint64) []byte {
 	nonce := make([]byte, len(hc.nonce))
 	copy(nonce, hc.nonce)
-	// Note that the 8 represents the size of a uint64 in bytes.
-	for i := 0; i < 8; i++ {
-		nonce[nonceSize-8+i] ^= byte(sequence >> uint64(56-8*i))
+	for i := 0; i < uint64Size; i++ {
+		nonce[nonceSize-uint64Size+i] ^= byte(sequence >> uint64(56-uint64Size*i))
 	}
 	return nonce
 }
 
 // deriveSecret implements Derive-Secret specified in
 // https://tools.ietf.org/html/rfc8446#section-7.1.
-func (hc *s2aHalfConnection) deriveSecret(secret, label []byte, length int) ([]byte, error) {
+func (hc *S2AHalfConnection) deriveSecret(secret, label []byte, length int) ([]byte, error) {
 	var hkdfLabel cryptobyte.Builder
 	hkdfLabel.AddUint16(uint16(length))
 	hkdfLabel.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
 		b.AddBytes(label)
+	})
+	// Append empty `Context` field, specified in the RFC. The Half Connection
+	// does not use the `Context` field.
+	hkdfLabel.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes([]byte(""))
 	})
 	hkdfLabelBytes, err := hkdfLabel.Bytes()
 	if err != nil {

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -5,12 +5,13 @@ import (
 	"golang.org/x/crypto/cryptobyte"
 	s2a_proto "google.golang.org/grpc/security/s2a/internal"
 	"hash"
+	"sync"
 )
 
 const (
 	tls13Key    = "tls13 key"
 	tls13Nonce  = "tls13 iv"
-	tls13Update = "tls13 update"
+	tls13Update = "tls13 upd"
 )
 
 type S2AHalfConnection struct {
@@ -18,6 +19,7 @@ type S2AHalfConnection struct {
 	aeadCrypter   s2aAeadCrypter
 	expander      hkdfExpander
 	seqCounter    counter
+	mutex         sync.Mutex
 	trafficSecret []byte
 	nonce         []byte
 }
@@ -28,31 +30,46 @@ func NewHalfConn(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte) (S2AHa
 		return S2AHalfConnection{}, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v", cs.trafficSecretSize(), trafficSecret)
 	}
 
-	hc := S2AHalfConnection{expander: &defaultHKDFExpander{}, seqCounter: newCounter()}
-	key, err := hc.deriveSecret(cs.hashFunction(), trafficSecret, []byte(tls13Key))
+	hc := S2AHalfConnection{h: cs.hashFunction(), expander: &defaultHKDFExpander{}, seqCounter: newCounter()}
+	key, err := hc.deriveSecret(hc.h, trafficSecret, []byte(tls13Key))
 	if err != nil {
 		return S2AHalfConnection{}, fmt.Errorf("hc.deriveSecret(h, %v, %v) failed with error: %v", trafficSecret, tls13Key, err)
 	}
-	hc.nonce, err = hc.deriveSecret(cs.hashFunction(), trafficSecret, []byte(tls13Nonce))
-	if err != nil {
-		return S2AHalfConnection{}, fmt.Errorf("hc.deriveSecret(h, %v, %v) failed with error: %v", trafficSecret, tls13Nonce, err)
-	}
-	hc.h = cs.hashFunction()
 	hc.aeadCrypter, err = cs.aeadCrypter(key)
 	if err != nil {
 		return S2AHalfConnection{}, fmt.Errorf("cs.aeadCrypter(%v) failed with error: %v", key, err)
+	}
+	hc.nonce, err = hc.deriveSecret(hc.h, trafficSecret, []byte(tls13Nonce))
+	if err != nil {
+		return S2AHalfConnection{}, fmt.Errorf("hc.deriveSecret(h, %v, %v) failed with error: %v", trafficSecret, tls13Nonce, err)
 	}
 	return hc, nil
 }
 
 func (hc *S2AHalfConnection) Encrypt(dst, plaintext, aad []byte) ([]byte, error) {
-	// TODO(rnkim): Implement this.
-	panic("Encrypt currently unimplemented")
+	hc.mutex.Lock()
+	sequence, err := hc.getAndIncrementSequence()
+	if err != nil {
+		hc.mutex.Unlock()
+		return nil, err
+	}
+	nonce := hc.maskedNonce(sequence)
+	crypter := hc.aeadCrypter
+	hc.mutex.Unlock()
+	return crypter.encrypt(dst, plaintext, nonce, aad)
 }
 
 func (hc *S2AHalfConnection) Decrypt(dst, ciphertext, aad []byte) ([]byte, error) {
-	// TODO(rnkim): Implement this.
-	panic("Decrypt currently unimplemented")
+	hc.mutex.Lock()
+	sequence, err := hc.getAndIncrementSequence()
+	if err != nil {
+		hc.mutex.Unlock()
+		return nil, err
+	}
+	nonce := hc.maskedNonce(sequence)
+	crypter := hc.aeadCrypter
+	hc.mutex.Unlock()
+	return crypter.decrypt(dst, ciphertext, nonce, aad)
 }
 
 func (hc *S2AHalfConnection) UpdateKey() error {
@@ -61,7 +78,36 @@ func (hc *S2AHalfConnection) UpdateKey() error {
 	if err != nil {
 		return fmt.Errorf("hc.deriveSecret(h, %v, %v) failed with error: %v", hc.trafficSecret, tls13Update, err)
 	}
+	key, err := hc.deriveSecret(hc.h, hc.trafficSecret, []byte(tls13Key))
+	if err != nil {
+		return fmt.Errorf("hc.deriveSecret(h, %v, %v) failed with error: %v", hc.trafficSecret, tls13Key, err)
+	}
+	err = hc.aeadCrypter.updateKey(key)
+	if err != nil {
+		return fmt.Errorf("hc.aeadCrypter.updateKey(%v) failed with error: %v", key, err)
+	}
+	hc.nonce, err = hc.deriveSecret(hc.h, hc.trafficSecret, []byte(tls13Nonce))
+	if err != nil {
+		return fmt.Errorf("hc.deriveSecret(h, %v, %v) failed with error: %v", hc.trafficSecret, tls13Nonce, err)
+	}
+	hc.seqCounter.reset()
 	return nil
+}
+
+func (hc *S2AHalfConnection) getAndIncrementSequence() (uint64, error) {
+	sequence, err := hc.seqCounter.val()
+	if err != nil {
+		return 0, err
+	}
+	hc.seqCounter.inc()
+	return sequence, nil
+}
+
+func (hc *S2AHalfConnection) maskedNonce(sequence uint64) []byte {
+	for i := 0; i < uint64Size; i++ {
+		hc.nonce[nonceSize-8+i] ^= sequence >> (56 - 8*i)
+	}
+	return hc.nonce
 }
 
 // deriveSecret implements Derive-Secret specified in

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -1,0 +1,49 @@
+package crypter
+
+import (
+	"fmt"
+	"golang.org/x/crypto/cryptobyte"
+	"hash"
+)
+
+type S2AHalfConnection struct {
+	aeadCrypter s2aAeadCrypter
+	expander    hkdfExpander
+	sequence    counter
+}
+
+func NewHalfConn(aeadCrypter s2aAeadCrypter, expander hkdfExpander) S2AHalfConnection {
+	return S2AHalfConnection{aeadCrypter, expander, newCounter()}
+}
+
+func (hc *S2AHalfConnection) Encrypt(dst, plaintext, aad []byte) ([]byte, error) {
+	// TODO(rnkim): Implement this.
+	panic("Encrypt currently unimplemented")
+}
+
+func (hc *S2AHalfConnection) Decrypt(dst, ciphertext, aad []byte) ([]byte, error) {
+	// TODO(rnkim): Implement this.
+	panic("Decrypt currently unimplemented")
+}
+
+func (hc *S2AHalfConnection) UpdateKey(key []byte) error {
+	// TODO(rnkim): Implement this.
+	panic("UpdateKey currently unimplemented")
+}
+
+// expandLabel implements HKDF-Expand-Label specified in
+// https://tools.ietf.org/html/rfc8446#section-7.1. Note that the `Context` and
+// `Length` parameters have been omitted since we always pass in an empty string
+// for `Context` and we used a fixed length.
+func (hc *S2AHalfConnection) expandLabel(h func() hash.Hash, secret, label []byte) ([]byte, error) {
+	var hkdfLabel cryptobyte.Builder
+	hkdfLabel.AddUint16(uint16(h().Size()))
+	hkdfLabel.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes(append([]byte("tls13 "), label...))
+	})
+	hkdfLabelBytes, err := hkdfLabel.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("hkdfExpandLabel failed with error: %v", err)
+	}
+	return hc.expander.expand(h, secret, hkdfLabelBytes)
+}

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -100,7 +100,9 @@ func (hc *S2AHalfConnection) UpdateKey() error {
 
 // updateCrypterAndNonce takes a new traffic secret and updates the crypter
 // and nonce. The updateCrypterKey flag determines whether a new AEAD crypter
-// is created or the existing one is updated with a new key.
+// is created or the existing one is updated with a new key. The
+// updateCrypterKey flag should only be set to false when called by the
+// constructor.
 func (hc *S2AHalfConnection) updateCrypterAndNonce(newTrafficSecret []byte, updateCrypterKey bool) error {
 	key, err := hc.deriveSecret(newTrafficSecret, []byte(tls13Key), hc.cs.keySize())
 	if err != nil {

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -1,19 +1,56 @@
 package crypter
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/sha3"
+	s2a_proto "google.golang.org/grpc/security/s2a/internal"
 	"hash"
 )
 
 type S2AHalfConnection struct {
-	aeadCrypter s2aAeadCrypter
-	expander    hkdfExpander
-	sequence    counter
+	aeadCrypter   s2aAeadCrypter
+	expander      hkdfExpander
+	seqCounter    counter
+	trafficSecret []byte
+	nonce         []byte
 }
 
-func NewHalfConn(aeadCrypter s2aAeadCrypter, expander hkdfExpander) S2AHalfConnection {
-	return S2AHalfConnection{aeadCrypter, expander, newCounter()}
+func NewHalfConn(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte) (S2AHalfConnection, error) {
+	var h func() hash.Hash
+	switch ciphersuite {
+	case s2a_proto.Ciphersuite_AES_128_GCM_SHA256:
+		h = sha256.New
+	case s2a_proto.Ciphersuite_AES_256_GCM_SHA384:
+		h = sha3.New384
+	case s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256:
+		h = sha256.New
+	}
+
+	hc := S2AHalfConnection{expander: &defaultHKDFExpander{}, seqCounter: newCounter()}
+	key, err := hc.deriveSecret(h, trafficSecret, []byte("tls13 key"))
+	if err != nil {
+		return S2AHalfConnection{}, fmt.Errorf("hc.deriveSecret(h, %v, \"tls13 key\") failed with error: %v", trafficSecret, err)
+	}
+	hc.nonce, err = hc.deriveSecret(h, trafficSecret, []byte("tls13 iv"))
+	if err != nil {
+		return S2AHalfConnection{}, fmt.Errorf("hc.deriveSecret(h, %v, \"tls13 iv\") failed with error: %v", trafficSecret, err)
+	}
+
+	switch ciphersuite {
+	case s2a_proto.Ciphersuite_AES_128_GCM_SHA256, s2a_proto.Ciphersuite_AES_256_GCM_SHA384:
+		crypter, err := newAESGCM(key)
+		if err != nil {
+			return S2AHalfConnection{}, fmt.Errorf("newAESGCM(%v) failed with error: %v", key, err)
+		}
+		hc.aeadCrypter = crypter
+	case s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256:
+		// TODO(rnkim): Implement this.
+		panic("unimplemented")
+	}
+
+	return hc, nil
 }
 
 func (hc *S2AHalfConnection) Encrypt(dst, plaintext, aad []byte) ([]byte, error) {
@@ -31,19 +68,19 @@ func (hc *S2AHalfConnection) UpdateKey(key []byte) error {
 	panic("UpdateKey currently unimplemented")
 }
 
-// expandLabel implements HKDF-Expand-Label specified in
+// deriveSecret implements Derive-Secret specified in
 // https://tools.ietf.org/html/rfc8446#section-7.1. Note that the `Context` and
 // `Length` parameters have been omitted since we always pass in an empty string
-// for `Context` and we used a fixed length.
-func (hc *S2AHalfConnection) expandLabel(h func() hash.Hash, secret, label []byte) ([]byte, error) {
+// for `Context` and we use a fixed length for `Length`.
+func (hc *S2AHalfConnection) deriveSecret(h func() hash.Hash, secret, label []byte) ([]byte, error) {
 	var hkdfLabel cryptobyte.Builder
 	hkdfLabel.AddUint16(uint16(h().Size()))
 	hkdfLabel.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
-		b.AddBytes(append([]byte("tls13 "), label...))
+		b.AddBytes(label)
 	})
 	hkdfLabelBytes, err := hkdfLabel.Bytes()
 	if err != nil {
-		return nil, fmt.Errorf("hkdfExpandLabel failed with error: %v", err)
+		return nil, fmt.Errorf("deriveSecret failed with error: %v", err)
 	}
 	return hc.expander.expand(h, secret, hkdfLabelBytes)
 }

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -29,14 +29,16 @@ type S2AHalfConnection struct {
 
 // NewHalfConn creates a new instance of S2AHalfConnection.
 func NewHalfConn(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte) (S2AHalfConnection, error) {
-	cs := newCiphersuite(ciphersuite)
+	cs, err := newCiphersuite(ciphersuite)
+	if err != nil {
+		return S2AHalfConnection{}, fmt.Errorf("failed to create new ciphersuite: %v", ciphersuite)
+	}
 	if cs.trafficSecretSize() != len(trafficSecret) {
 		return S2AHalfConnection{}, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
 	}
 
 	hc := S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(), trafficSecret: trafficSecret}
 
-	var err error
 	if err = hc.updateCrypterAndNonce(hc.trafficSecret, false /* updateCrypterKey */); err != nil {
 		return S2AHalfConnection{}, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
 	}

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -3,7 +3,7 @@ package crypter
 import (
 	"fmt"
 	"golang.org/x/crypto/cryptobyte"
-	s2a_proto "google.golang.org/grpc/security/s2a/internal/proto"
+	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
 	"hash"
 	"sync"
 )
@@ -32,18 +32,18 @@ type S2AHalfConnection struct {
 
 // NewHalfConn creates a new instance of S2AHalfConnection given a ciphersuite
 // and a traffic secret.
-func NewHalfConn(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte) (S2AHalfConnection, error) {
+func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte) (*S2AHalfConnection, error) {
 	cs, err := newCiphersuite(ciphersuite)
 	if err != nil {
-		return S2AHalfConnection{}, fmt.Errorf("failed to create new ciphersuite: %v", ciphersuite)
+		return nil, fmt.Errorf("failed to create new ciphersuite: %v", ciphersuite)
 	}
 	if cs.trafficSecretSize() != len(trafficSecret) {
-		return S2AHalfConnection{}, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
+		return nil, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
 	}
 
-	hc := S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(), trafficSecret: trafficSecret}
+	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(), trafficSecret: trafficSecret}
 	if err = hc.updateCrypterAndNonce(hc.trafficSecret); err != nil {
-		return S2AHalfConnection{}, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
+		return nil, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
 	}
 
 	return hc, nil

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -123,7 +123,7 @@ func TestGetAndIncrementSequence(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			hc := S2AHalfConnection{sequence: counter{val: tc.counter}}
 			// Make first getAndIncrement call. This should return the same value
-			// which was given.
+			// that was given.
 			value, err := hc.getAndIncrementSequence()
 			if err != nil {
 				t.Errorf("S2A counter starting with %v, hc.getAndIncrementSequence() failed, err = %v", tc.counter, err)
@@ -258,76 +258,6 @@ func TestNewHalfConn(t *testing.T) {
 				if got, want := hc.aeadCrypter, aeadCrypter; !aeadCrypterEqual(got, want, t) {
 					t.Errorf("aeadCrypterEqual returned false, expected true")
 				}
-			}
-		})
-	}
-}
-
-func TestS2AHalfConnectionEncrypt(t *testing.T) {
-	for _, tc := range []struct {
-		ciphersuite                                                  s2a_proto.Ciphersuite
-		trafficSecret                                                []byte
-		expectedCiphertext, expectedCiphertext2, expectedCiphertext3 []byte
-	}{
-		{
-			ciphersuite:         s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
-			trafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-			expectedCiphertext:  testutil.Dehex("f2e4e411ac674e01385e7ae9db54c97a9ae3d1842e51"),
-			expectedCiphertext2: testutil.Dehex("d7853afd6d7ceaababded0348f9a9c3a5b52544f0033d7c7ad"),
-			expectedCiphertext3: testutil.Dehex("af778b0e98365c4ee2174f17aab4aa0aba58eab1"),
-		},
-		{
-			ciphersuite:         s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
-			trafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-			expectedCiphertext:  testutil.Dehex("24efee5af1a665e6bb188e79544a7e974c707d690c5f"),
-			expectedCiphertext2: testutil.Dehex("832a5fd271b6442e743d6e30dcd66441846e719143b2acb9f4"),
-			expectedCiphertext3: testutil.Dehex("96cb84cc897caf296f9663fbc376243c7b53239c"),
-		},
-		{
-			ciphersuite:         s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
-			trafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-			expectedCiphertext:  testutil.Dehex("c947ffa470308b19d9a086b05ccb75d8c94abb704aae"),
-			expectedCiphertext2: testutil.Dehex("0cedeb922170c110c1f11bc03ffffbb2f5a9393d51b8d52f14"),
-			expectedCiphertext3: testutil.Dehex("924a53438593d1d76e54799b9ee8f35f2cee20dc"),
-		},
-	} {
-		t.Run(tc.ciphersuite.String(), func(t *testing.T) {
-			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
-			if err != nil {
-				t.Fatalf("NewHalfConn(%v, %v) failed, err = %v", tc.ciphersuite, tc.trafficSecret, err)
-			}
-
-			// Test encrypt with sequence 0.
-			const plaintext = "123456"
-			buf := []byte(plaintext)
-			ciphertext, err := hc.Encrypt(buf[:0], buf, nil)
-			if err != nil {
-				t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf[:0], buf, err)
-			}
-			if got, want := ciphertext, tc.expectedCiphertext; !bytes.Equal(got, want) {
-				t.Fatalf("Encrypt(%v, %v, nil) = %v, want %v", buf[:0], buf, got, want)
-			}
-
-			// Test encrypt with sequence 1.
-			const plaintext2 = "789123456"
-			buf2 := []byte(plaintext2)
-			ciphertext2, err := hc.Encrypt(buf2[:0], buf2, nil)
-			if err != nil {
-				t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf2[:0], buf2, err)
-			}
-			if got, want := ciphertext2, tc.expectedCiphertext2; !bytes.Equal(got, want) {
-				t.Fatalf("Encrypt(%v, %v, nil) = %v, want %v", buf2[:0], buf2, got, want)
-			}
-
-			// Test encrypt with sequence 2.
-			const plaintext3 = "7891"
-			buf3 := []byte(plaintext3)
-			ciphertext3, err := hc.Encrypt(buf3[:0], buf3, nil)
-			if err != nil {
-				t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf3[:0], buf3, err)
-			}
-			if got, want := ciphertext3, tc.expectedCiphertext3; !bytes.Equal(got, want) {
-				t.Fatalf("Encrypt(%v, %v, nil) = %v, want %v", buf3[:0], buf3, got, want)
 			}
 		})
 	}

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -1,0 +1,142 @@
+package crypter
+
+import (
+	"fmt"
+	"google.golang.org/grpc/security/s2a/internal/crypter/testutil"
+	s2a_proto "google.golang.org/grpc/security/s2a/internal/proto"
+	"testing"
+)
+
+// getHalfConnPair returns a sender/receiver pair of S2A Half Connections.
+func getHalfConnPair(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte, t *testing.T) (s2aHalfConnection, s2aHalfConnection) {
+	sender, err := newHalfConn(ciphersuite, trafficSecret)
+	if err != nil {
+		t.Fatalf("sender side newHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
+	}
+	receiver, err := newHalfConn(ciphersuite, trafficSecret)
+	if err != nil {
+		t.Fatalf("receiver side newHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
+	}
+	return sender, receiver
+}
+
+func testHalfConnRoundtrip(sender s2aHalfConnection, receiver s2aHalfConnection, t *testing.T) {
+	// Encrypt first message.
+	const plaintext = "This is plaintext."
+	buf := []byte(plaintext)
+	_, err := sender.encrypt(buf[:0], buf, nil)
+	if err != nil {
+		t.Fatalf("encrypt(%v, %v, nil) failed, err = %v", buf[:0], buf, err)
+	}
+
+	// Encrypt second message.
+	const plaintext2 = "This is a second plaintext."
+	buf2 := []byte(plaintext2)
+	ciphertext2, err := sender.encrypt(buf2[:0], buf2, nil)
+	if err != nil {
+		t.Fatalf("encrypt(%v, %v, nil) failed, err = %v", buf2[:0], buf2, err)
+	}
+
+	// Decryption fails: cannot decrypt second message before first.
+	if _, err := receiver.decrypt(nil, ciphertext2, nil); err == nil {
+		t.Errorf("decrypt(nil, %v, nil) expected an error, received none", ciphertext2)
+	}
+
+	// Decrypt second message. This works now because the sequence number was
+	// incremented by the previous call to decrypt.
+	decryptedPlaintext2, err := receiver.decrypt(ciphertext2[:0], ciphertext2, nil)
+	if err != nil {
+		t.Fatalf("decrypt(%v, %v, nil) failed, err = %v", ciphertext2[:0], ciphertext2, err)
+	}
+	if got, want := string(decryptedPlaintext2), plaintext2; got != want {
+		t.Fatalf("decrypt(%v, %v, nil) = %v, want %v", ciphertext2[:0], ciphertext2, got, want)
+	}
+
+	// Decryption fails: same message decrypted again.
+	if _, err := receiver.decrypt(nil, ciphertext2, nil); err == nil {
+		t.Errorf("decrypt(nil, %v, nil) expected an error, received none", ciphertext2)
+	}
+}
+
+func TestNewHalfConn(t *testing.T) {
+	for _, tc := range []struct {
+		ciphersuite   s2a_proto.Ciphersuite
+		trafficSecret []byte
+		shouldFail    bool
+	}{
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("00"),
+			shouldFail:    true,
+		},
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+		},
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("00"),
+			shouldFail:    true,
+		},
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+		},
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("00"),
+			shouldFail:    true,
+		},
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+		},
+	} {
+		t.Run(fmt.Sprintf("%v/shouldFail=%v", tc.ciphersuite.String(), tc.shouldFail), func(t *testing.T) {
+			// TODO(rnkim): Remove below.
+			if tc.ciphersuite == s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256 {
+				return
+			}
+
+			_, err := newHalfConn(tc.ciphersuite, tc.trafficSecret)
+			if got, want := err == nil, !tc.shouldFail; got != want {
+				t.Errorf("newHalfConn(%v, %v)=(err=nil)=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
+			}
+
+		})
+	}
+}
+
+func TestS2AHalfConnectionEncryptDecrypt(t *testing.T) {
+	for _, tc := range []struct {
+		ciphersuite   s2a_proto.Ciphersuite
+		trafficSecret []byte
+	}{
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+		},
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+		},
+		{
+			ciphersuite:   s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+		},
+	} {
+		t.Run(tc.ciphersuite.String(), func(t *testing.T) {
+			// TODO(rnkim): Remove below.
+			if tc.ciphersuite == s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256 {
+				return
+			}
+			sender, receiver := getHalfConnPair(tc.ciphersuite, tc.trafficSecret, t)
+			testHalfConnRoundtrip(sender, receiver, t)
+		})
+	}
+
+}
+
+func TestS2AHalfConnectionUpdateKey(t *testing.T) {
+
+}

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -2,7 +2,6 @@ package crypter
 
 import (
 	"bytes"
-	"fmt"
 	"google.golang.org/grpc/security/s2a/internal/crypter/testutil"
 	s2a_proto "google.golang.org/grpc/security/s2a/internal/proto"
 	"math"
@@ -13,27 +12,27 @@ import (
 func getHalfConnPair(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte, t *testing.T) (S2AHalfConnection, S2AHalfConnection) {
 	sender, err := NewHalfConn(ciphersuite, trafficSecret)
 	if err != nil {
-		t.Fatalf("sender side NewHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
+		t.Fatalf("sender side NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
 	}
 	receiver, err := NewHalfConn(ciphersuite, trafficSecret)
 	if err != nil {
-		t.Fatalf("receiver side NewHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
+		t.Fatalf("receiver side NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
 	}
 	return sender, receiver
 }
 
-// aeadCrypterEqual checks whether the given s2aAeadCrypters encode a simple
+// aeadCrypterEqual checks whether the given s2aAeadCrypters encrypt a simple
 // string identically.
 func aeadCrypterEqual(a s2aAeadCrypter, b s2aAeadCrypter, t *testing.T) bool {
 	nonce := make([]byte, nonceSize)
 	const plaintext = "This is plaintext"
 	ciphertextA, err := a.encrypt(nil, []byte(plaintext), nonce, nil)
 	if err != nil {
-		t.Errorf("a.encrypt(nil, %v, %v, nil) failed, err = %v", []byte(plaintext), nonce, err)
+		t.Errorf("a.encrypt(nil, %v, %v, nil) failed: %v", []byte(plaintext), nonce, err)
 	}
 	ciphertextB, err := b.encrypt(nil, []byte(plaintext), nonce, nil)
 	if err != nil {
-		t.Errorf("b.encrypt(nil, %v, %v, nil) failed, err = %v", []byte(plaintext), nonce, err)
+		t.Errorf("b.encrypt(nil, %v, %v, nil) failed: %v", []byte(plaintext), nonce, err)
 	}
 	return bytes.Equal(ciphertextA, ciphertextB)
 }
@@ -44,7 +43,7 @@ func testHalfConnRoundtrip(sender S2AHalfConnection, receiver S2AHalfConnection,
 	buf := []byte(plaintext)
 	_, err := sender.Encrypt(buf[:0], buf, nil)
 	if err != nil {
-		t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf[:0], buf, err)
+		t.Fatalf("Encrypt(%v, %v, nil) failed: %v", buf[:0], buf, err)
 	}
 
 	// Encrypt second message.
@@ -52,7 +51,7 @@ func testHalfConnRoundtrip(sender S2AHalfConnection, receiver S2AHalfConnection,
 	buf2 := []byte(plaintext2)
 	ciphertext2, err := sender.Encrypt(buf2[:0], buf2, nil)
 	if err != nil {
-		t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf2[:0], buf2, err)
+		t.Fatalf("Encrypt(%v, %v, nil) failed: %v", buf2[:0], buf2, err)
 	}
 
 	// Encrypt empty message.
@@ -60,7 +59,7 @@ func testHalfConnRoundtrip(sender S2AHalfConnection, receiver S2AHalfConnection,
 	buf3 := []byte(plaintext3)
 	ciphertext3, err := sender.Encrypt(buf3[:0], buf3, nil)
 	if err != nil {
-		t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf3[:0], buf3, err)
+		t.Fatalf("Encrypt(%v, %v, nil) failed: %v", buf3[:0], buf3, err)
 	}
 
 	// Decryption fails: cannot decrypt second message before first.
@@ -72,7 +71,7 @@ func testHalfConnRoundtrip(sender S2AHalfConnection, receiver S2AHalfConnection,
 	// incremented by the previous call to decrypt.
 	decryptedPlaintext2, err := receiver.Decrypt(ciphertext2[:0], ciphertext2, nil)
 	if err != nil {
-		t.Fatalf("Decrypt(%v, %v, nil) failed, err = %v", ciphertext2[:0], ciphertext2, err)
+		t.Fatalf("Decrypt(%v, %v, nil) failed: %v", ciphertext2[:0], ciphertext2, err)
 	}
 	if got, want := string(decryptedPlaintext2), plaintext2; got != want {
 		t.Fatalf("Decrypt(%v, %v, nil) = %v, want %v", ciphertext2[:0], ciphertext2, got, want)
@@ -81,7 +80,7 @@ func testHalfConnRoundtrip(sender S2AHalfConnection, receiver S2AHalfConnection,
 	// Decrypt third (empty) message.
 	decryptedPlaintext3, err := receiver.Decrypt(ciphertext3[:0], ciphertext3, nil)
 	if err != nil {
-		t.Fatalf("Decrypt(%v, %v, nil) failed, err = %v", ciphertext3[:0], ciphertext3, err)
+		t.Fatalf("Decrypt(%v, %v, nil) failed: %v", ciphertext3[:0], ciphertext3, err)
 	}
 	if got, want := string(decryptedPlaintext3), plaintext3; got != want {
 		t.Fatalf("Decrypt(%v, %v, nil) = %v, want %v", ciphertext3[:0], ciphertext3, got, want)
@@ -126,7 +125,7 @@ func TestGetAndIncrementSequence(t *testing.T) {
 			// that was given.
 			value, err := hc.getAndIncrementSequence()
 			if err != nil {
-				t.Errorf("S2A counter starting with %v, hc.getAndIncrementSequence() failed, err = %v", tc.counter, err)
+				t.Errorf("S2A counter starting with %v, hc.getAndIncrementSequence() failed: %v", tc.counter, err)
 			}
 			if value != tc.counter {
 				t.Errorf("S2A counter starting with %v, hc.getAndIncrementSequence() = %v, want %v", tc.counter, value, tc.counter)
@@ -200,68 +199,76 @@ func TestMaskedNonce(t *testing.T) {
 
 func TestNewHalfConn(t *testing.T) {
 	for _, tc := range []struct {
+		desc                      string
 		ciphersuite               s2a_proto.Ciphersuite
 		trafficSecret, key, nonce []byte
 		shouldFail                bool
 	}{
 		{
+			desc:          "AES-128-GCM-SHA256 invalid traffic secret",
 			ciphersuite:   s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
 			trafficSecret: testutil.Dehex("00"),
 			shouldFail:    true,
 		},
 		{
+			desc:          "AES-128-GCM-SHA256 valid",
 			ciphersuite:   s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
 			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 			key:           testutil.Dehex("c3ae7509cfced2b803a6186956cda79f"),
 			nonce:         testutil.Dehex("b5803d82ad8854d2e598187f"),
 		},
 		{
+			desc:          "AES-256-GCM-SHA384 invalid traffic secret",
 			ciphersuite:   s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
 			trafficSecret: testutil.Dehex("00"),
 			shouldFail:    true,
 		},
 		{
+			desc:          "AES-256-GCM-SHA384 valid",
 			ciphersuite:   s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
 			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 			key:           testutil.Dehex("dac731ae4866677ed2f65c490e18817be5cbbbd03f597ad59041c117b731109a"),
 			nonce:         testutil.Dehex("4db152d27d180b1ee48fa89d"),
 		},
 		{
+			desc:          "CHACHA20-POLY1305-SHA256 invalid traffic secret",
 			ciphersuite:   s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
 			trafficSecret: testutil.Dehex("00"),
 			shouldFail:    true,
 		},
 		{
+			desc:          "CHACHA20-POLY1305-SHA256 valid",
 			ciphersuite:   s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
 			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 			key:           testutil.Dehex("130e2000508ace00ef265e172d09892e467256cb90dad9de99543cf548be6a8b"),
 			nonce:         testutil.Dehex("b5803d82ad8854d2e598187f"),
 		},
 	} {
-		t.Run(fmt.Sprintf("%v/shouldFail=%v", tc.ciphersuite.String(), tc.shouldFail), func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
 			if got, want := err == nil, !tc.shouldFail; got != want {
 				t.Errorf("NewHalfConn(%v, %v)=(err=nil)=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
 			}
-			if err == nil {
-				// Check that the traffic secret wasn't changed.
-				if got, want := hc.trafficSecret, tc.trafficSecret; !bytes.Equal(got, want) {
-					t.Errorf("NewHalfConn(%v, %v).trafficSecret=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
-				}
-				if got, want := hc.nonce, tc.nonce; !bytes.Equal(got, want) {
-					t.Errorf("NewHalfConn(%v, %v).nonce=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
-				}
-				cs, err := newCiphersuite(tc.ciphersuite)
-				if err != nil {
-					t.Errorf("newCipherSuite(%v) failed, err = %v", tc.ciphersuite, err)
-				}
-				aeadCrypter, err := cs.aeadCrypter(tc.key)
-				if err != nil {
-					t.Errorf("cs.aeadCrypter(%v) failed, err = %v", tc.key, err)
-				}
-				if got, want := hc.aeadCrypter, aeadCrypter; !aeadCrypterEqual(got, want, t) {
-					t.Errorf("aeadCrypterEqual returned false, expected true")
-				}
+			if err != nil {
+				return
+			}
+			// Check that the traffic secret wasn't changed.
+			if got, want := hc.trafficSecret, tc.trafficSecret; !bytes.Equal(got, want) {
+				t.Errorf("NewHalfConn(%v, %v).trafficSecret=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
+			}
+			if got, want := hc.nonce, tc.nonce; !bytes.Equal(got, want) {
+				t.Errorf("NewHalfConn(%v, %v).nonce=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
+			}
+			cs, err := newCiphersuite(tc.ciphersuite)
+			if err != nil {
+				t.Errorf("newCipherSuite(%v) failed: %v", tc.ciphersuite, err)
+			}
+			aeadCrypter, err := cs.aeadCrypter(tc.key)
+			if err != nil {
+				t.Errorf("cs.aeadCrypter(%v) failed: %v", tc.key, err)
+			}
+			if got, want := hc.aeadCrypter, aeadCrypter; !aeadCrypterEqual(got, want, t) {
+				t.Errorf("aeadCrypterEqual returned false, expected true")
 			}
 		})
 	}
@@ -322,10 +329,10 @@ func TestS2AHalfConnectionUpdateKey(t *testing.T) {
 		t.Run(tc.ciphersuite.String(), func(t *testing.T) {
 			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
 			if err != nil {
-				t.Fatalf("NewHalfConn(%v, %v) failed, err = %v", tc.ciphersuite, tc.trafficSecret, err)
+				t.Fatalf("NewHalfConn(%v, %v) failed: %v", tc.ciphersuite, tc.trafficSecret, err)
 			}
 			if err := hc.UpdateKey(); err != nil {
-				t.Fatalf("hc.updateKey() failed, err = %v", err)
+				t.Fatalf("hc.updateKey() failed: %v", err)
 			}
 			if got, want := hc.trafficSecret, tc.advancedTrafficSecret; !bytes.Equal(got, want) {
 				t.Errorf("hc.trafficSecret = %v, want %v", got, want)
@@ -335,11 +342,11 @@ func TestS2AHalfConnectionUpdateKey(t *testing.T) {
 			}
 			cs, err := newCiphersuite(tc.ciphersuite)
 			if err != nil {
-				t.Errorf("newCipherSuite(%v) failed, err = %v", tc.ciphersuite, err)
+				t.Errorf("newCipherSuite(%v) failed: %v", tc.ciphersuite, err)
 			}
 			aeadCrypter, err := cs.aeadCrypter(tc.key)
 			if err != nil {
-				t.Errorf("cs.aeadCrypter(%v) failed, err = %v", tc.key, err)
+				t.Errorf("cs.aeadCrypter(%v) failed: %v", tc.key, err)
 			}
 			if got, want := hc.aeadCrypter, aeadCrypter; !aeadCrypterEqual(got, want, t) {
 				t.Errorf("aeadCrypterEqual returned false, expected true")

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -205,8 +205,8 @@ func TestNewHalfConn(t *testing.T) {
 		shouldFail                bool
 	}{
 		// The traffic secrets were chosen randomly and are equivalent to the
-		// ones used C++ and Java. The key and nonce were constructed using an
-		// existing TLS library.
+		// ones used in C++ and Java. The key and nonce were constructed using
+		// an existing TLS library.
 		{
 			desc:          "AES-128-GCM-SHA256 invalid traffic secret",
 			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
@@ -308,8 +308,8 @@ func TestS2AHalfConnectionUpdateKey(t *testing.T) {
 		trafficSecret, advancedTrafficSecret, key, nonce []byte
 	}{
 		// The traffic secrets were chosen randomly and are equivalent to the
-		// ones used C++ and Java. The advanced traffic secret, key, and nonce
-		// were constructed using an existing TLS library.
+		// ones used in C++ and Java. The advanced traffic secret, key, and
+		// nonce were constructed using an existing TLS library.
 		{
 			ciphersuite:           s2apb.Ciphersuite_AES_128_GCM_SHA256,
 			trafficSecret:         testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -251,9 +251,13 @@ func TestNewHalfConn(t *testing.T) {
 				if got, want := hc.nonce, tc.nonce; !bytes.Equal(got, want) {
 					t.Errorf("NewHalfConn(%v, %v).nonce=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
 				}
-				aeadCrypter, err := newCiphersuite(tc.ciphersuite).aeadCrypter(tc.key)
+				cs, err := newCiphersuite(tc.ciphersuite)
 				if err != nil {
-					t.Errorf("newCipherSuite(%v).aeadCrypter(%v) failed, err = %v", tc.ciphersuite, tc.key, err)
+					t.Errorf("newCipherSuite(%v) failed, err = %v", tc.ciphersuite, err)
+				}
+				aeadCrypter, err := cs.aeadCrypter(tc.key)
+				if err != nil {
+					t.Errorf("cs.aeadCrypter(%v) failed, err = %v", tc.key, err)
 				}
 				if got, want := hc.aeadCrypter, aeadCrypter; !aeadCrypterEqual(got, want, t) {
 					t.Errorf("aeadCrypterEqual returned false, expected true")
@@ -329,9 +333,13 @@ func TestS2AHalfConnectionUpdateKey(t *testing.T) {
 			if got, want := hc.nonce, tc.nonce; !bytes.Equal(got, want) {
 				t.Errorf("hc.nonce = %v, want %v", got, want)
 			}
-			aeadCrypter, err := newCiphersuite(tc.ciphersuite).aeadCrypter(tc.key)
+			cs, err := newCiphersuite(tc.ciphersuite)
 			if err != nil {
-				t.Errorf("newCipherSuite(%v).aeadCrypter(%v) failed, err = %v", tc.ciphersuite, tc.key, err)
+				t.Errorf("newCipherSuite(%v) failed, err = %v", tc.ciphersuite, err)
+			}
+			aeadCrypter, err := cs.aeadCrypter(tc.key)
+			if err != nil {
+				t.Errorf("cs.aeadCrypter(%v) failed, err = %v", tc.key, err)
 			}
 			if got, want := hc.aeadCrypter, aeadCrypter; !aeadCrypterEqual(got, want, t) {
 				t.Errorf("aeadCrypterEqual returned false, expected true")

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -1,6 +1,7 @@
 package crypter
 
 import (
+	"bytes"
 	"fmt"
 	"google.golang.org/grpc/security/s2a/internal/crypter/testutil"
 	s2a_proto "google.golang.org/grpc/security/s2a/internal/proto"
@@ -8,61 +9,61 @@ import (
 )
 
 // getHalfConnPair returns a sender/receiver pair of S2A Half Connections.
-func getHalfConnPair(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte, t *testing.T) (s2aHalfConnection, s2aHalfConnection) {
-	sender, err := newHalfConn(ciphersuite, trafficSecret)
+func getHalfConnPair(ciphersuite s2a_proto.Ciphersuite, trafficSecret []byte, t *testing.T) (S2AHalfConnection, S2AHalfConnection) {
+	sender, err := NewHalfConn(ciphersuite, trafficSecret)
 	if err != nil {
-		t.Fatalf("sender side newHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
+		t.Fatalf("sender side NewHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
 	}
-	receiver, err := newHalfConn(ciphersuite, trafficSecret)
+	receiver, err := NewHalfConn(ciphersuite, trafficSecret)
 	if err != nil {
-		t.Fatalf("receiver side newHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
+		t.Fatalf("receiver side NewHalfConn(%v, %v) failed, err = %v", ciphersuite, trafficSecret, err)
 	}
 	return sender, receiver
 }
 
-func testHalfConnRoundtrip(sender s2aHalfConnection, receiver s2aHalfConnection, t *testing.T) {
+func testHalfConnRoundtrip(sender S2AHalfConnection, receiver S2AHalfConnection, t *testing.T) {
 	// Encrypt first message.
 	const plaintext = "This is plaintext."
 	buf := []byte(plaintext)
-	_, err := sender.encrypt(buf[:0], buf, nil)
+	_, err := sender.Encrypt(buf[:0], buf, nil)
 	if err != nil {
-		t.Fatalf("encrypt(%v, %v, nil) failed, err = %v", buf[:0], buf, err)
+		t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf[:0], buf, err)
 	}
 
 	// Encrypt second message.
 	const plaintext2 = "This is a second plaintext."
 	buf2 := []byte(plaintext2)
-	ciphertext2, err := sender.encrypt(buf2[:0], buf2, nil)
+	ciphertext2, err := sender.Encrypt(buf2[:0], buf2, nil)
 	if err != nil {
-		t.Fatalf("encrypt(%v, %v, nil) failed, err = %v", buf2[:0], buf2, err)
+		t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf2[:0], buf2, err)
 	}
 
 	// Decryption fails: cannot decrypt second message before first.
-	if _, err := receiver.decrypt(nil, ciphertext2, nil); err == nil {
-		t.Errorf("decrypt(nil, %v, nil) expected an error, received none", ciphertext2)
+	if _, err := receiver.Decrypt(nil, ciphertext2, nil); err == nil {
+		t.Errorf("Decrypt(nil, %v, nil) expected an error, received none", ciphertext2)
 	}
 
 	// Decrypt second message. This works now because the sequence number was
 	// incremented by the previous call to decrypt.
-	decryptedPlaintext2, err := receiver.decrypt(ciphertext2[:0], ciphertext2, nil)
+	decryptedPlaintext2, err := receiver.Decrypt(ciphertext2[:0], ciphertext2, nil)
 	if err != nil {
-		t.Fatalf("decrypt(%v, %v, nil) failed, err = %v", ciphertext2[:0], ciphertext2, err)
+		t.Fatalf("Decrypt(%v, %v, nil) failed, err = %v", ciphertext2[:0], ciphertext2, err)
 	}
 	if got, want := string(decryptedPlaintext2), plaintext2; got != want {
-		t.Fatalf("decrypt(%v, %v, nil) = %v, want %v", ciphertext2[:0], ciphertext2, got, want)
+		t.Fatalf("Decrypt(%v, %v, nil) = %v, want %v", ciphertext2[:0], ciphertext2, got, want)
 	}
 
 	// Decryption fails: same message decrypted again.
-	if _, err := receiver.decrypt(nil, ciphertext2, nil); err == nil {
-		t.Errorf("decrypt(nil, %v, nil) expected an error, received none", ciphertext2)
+	if _, err := receiver.Decrypt(nil, ciphertext2, nil); err == nil {
+		t.Errorf("Decrypt(nil, %v, nil) expected an error, received none", ciphertext2)
 	}
 }
 
 func TestNewHalfConn(t *testing.T) {
 	for _, tc := range []struct {
-		ciphersuite   s2a_proto.Ciphersuite
-		trafficSecret []byte
-		shouldFail    bool
+		ciphersuite               s2a_proto.Ciphersuite
+		trafficSecret, key, nonce []byte
+		shouldFail                bool
 	}{
 		{
 			ciphersuite:   s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
@@ -72,6 +73,8 @@ func TestNewHalfConn(t *testing.T) {
 		{
 			ciphersuite:   s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
 			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			key:           testutil.Dehex("c3ae7509cfced2b803a6186956cda79f"),
+			nonce:         testutil.Dehex("b5803d82ad8854d2e598187f"),
 		},
 		{
 			ciphersuite:   s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
@@ -81,6 +84,8 @@ func TestNewHalfConn(t *testing.T) {
 		{
 			ciphersuite:   s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
 			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			key:           testutil.Dehex("dac731ae4866677ed2f65c490e18817be5cbbbd03f597ad59041c117b731109a"),
+			nonce:         testutil.Dehex("4db152d27d180b1ee48fa89d"),
 		},
 		{
 			ciphersuite:   s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
@@ -90,24 +95,102 @@ func TestNewHalfConn(t *testing.T) {
 		{
 			ciphersuite:   s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
 			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			key:           testutil.Dehex("130e2000508ace00ef265e172d09892e467256cb90dad9de99543cf548be6a8b"),
+			nonce:         testutil.Dehex("b5803d82ad8854d2e598187f"),
 		},
 	} {
 		t.Run(fmt.Sprintf("%v/shouldFail=%v", tc.ciphersuite.String(), tc.shouldFail), func(t *testing.T) {
-			// TODO(rnkim): Remove below.
-			if tc.ciphersuite == s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256 {
-				return
-			}
-
-			_, err := newHalfConn(tc.ciphersuite, tc.trafficSecret)
+			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
 			if got, want := err == nil, !tc.shouldFail; got != want {
-				t.Errorf("newHalfConn(%v, %v)=(err=nil)=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
+				t.Errorf("NewHalfConn(%v, %v)=(err=nil)=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
 			}
-
+			if err == nil {
+				// Check that the traffic secret wasn't changed.
+				if got, want := hc.trafficSecret, tc.trafficSecret; !bytes.Equal(got, want) {
+					t.Errorf("NewHalfConn(%v, %v).trafficSecret=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
+				}
+				if got, want := hc.key, tc.key; !bytes.Equal(got, want) {
+					t.Errorf("NewHalfConn(%v, %v).key=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
+				}
+				if got, want := hc.nonce, tc.nonce; !bytes.Equal(got, want) {
+					t.Errorf("NewHalfConn(%v, %v).nonce=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
+				}
+			}
 		})
 	}
 }
 
-func TestS2AHalfConnectionEncryptDecrypt(t *testing.T) {
+func TestS2AHalfConnectionEncrypt(t *testing.T) {
+	for _, tc := range []struct {
+		ciphersuite                                                  s2a_proto.Ciphersuite
+		trafficSecret                                                []byte
+		expectedCiphertext, expectedCiphertext2, expectedCiphertext3 []byte
+	}{
+		{
+			ciphersuite:         s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			expectedCiphertext:  testutil.Dehex("f2e4e411ac674e01385e7ae9db54c97a9ae3d1842e51"),
+			expectedCiphertext2: testutil.Dehex("d7853afd6d7ceaababded0348f9a9c3a5b52544f0033d7c7ad"),
+			expectedCiphertext3: testutil.Dehex("af778b0e98365c4ee2174f17aab4aa0aba58eab1"),
+		},
+		{
+			ciphersuite:         s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			expectedCiphertext:  testutil.Dehex("24efee5af1a665e6bb188e79544a7e974c707d690c5f"),
+			expectedCiphertext2: testutil.Dehex("832a5fd271b6442e743d6e30dcd66441846e719143b2acb9f4"),
+			expectedCiphertext3: testutil.Dehex("96cb84cc897caf296f9663fbc376243c7b53239c"),
+		},
+		{
+			ciphersuite:         s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			expectedCiphertext:  testutil.Dehex("c947ffa470308b19d9a086b05ccb75d8c94abb704aae"),
+			expectedCiphertext2: testutil.Dehex("0cedeb922170c110c1f11bc03ffffbb2f5a9393d51b8d52f14"),
+			expectedCiphertext3: testutil.Dehex("924a53438593d1d76e54799b9ee8f35f2cee20dc"),
+		},
+	} {
+		t.Run(tc.ciphersuite.String(), func(t *testing.T) {
+			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
+			if err != nil {
+				t.Fatalf("NewHalfConn(%v, %v) failed, err = %v", tc.ciphersuite, tc.trafficSecret, err)
+			}
+
+			// Test encrypt with sequence 0.
+			const plaintext = "123456"
+			buf := []byte(plaintext)
+			ciphertext, err := hc.Encrypt(buf[:0], buf, nil)
+			if err != nil {
+				t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf[:0], buf, err)
+			}
+			if got, want := ciphertext, tc.expectedCiphertext; !bytes.Equal(got, want) {
+				t.Fatalf("Encrypt(%v, %v, nil) = %v, want %v", buf[:0], buf, got, want)
+			}
+
+			// Test encrypt with sequence 1.
+			const plaintext2 = "789123456"
+			buf2 := []byte(plaintext2)
+			ciphertext2, err := hc.Encrypt(buf2[:0], buf2, nil)
+			if err != nil {
+				t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf2[:0], buf2, err)
+			}
+			if got, want := ciphertext2, tc.expectedCiphertext2; !bytes.Equal(got, want) {
+				t.Fatalf("Encrypt(%v, %v, nil) = %v, want %v", buf2[:0], buf2, got, want)
+			}
+
+			// Test encrypt with sequence 2.
+			const plaintext3 = "7891"
+			buf3 := []byte(plaintext3)
+			ciphertext3, err := hc.Encrypt(buf3[:0], buf3, nil)
+			if err != nil {
+				t.Fatalf("Encrypt(%v, %v, nil) failed, err = %v", buf3[:0], buf3, err)
+			}
+			if got, want := ciphertext3, tc.expectedCiphertext3; !bytes.Equal(got, want) {
+				t.Fatalf("Encrypt(%v, %v, nil) = %v, want %v", buf3[:0], buf3, got, want)
+			}
+		})
+	}
+}
+
+func TestS2AHalfConnectionRoundtrip(t *testing.T) {
 	for _, tc := range []struct {
 		ciphersuite   s2a_proto.Ciphersuite
 		trafficSecret []byte
@@ -126,17 +209,56 @@ func TestS2AHalfConnectionEncryptDecrypt(t *testing.T) {
 		},
 	} {
 		t.Run(tc.ciphersuite.String(), func(t *testing.T) {
-			// TODO(rnkim): Remove below.
-			if tc.ciphersuite == s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256 {
-				return
-			}
 			sender, receiver := getHalfConnPair(tc.ciphersuite, tc.trafficSecret, t)
 			testHalfConnRoundtrip(sender, receiver, t)
 		})
 	}
-
 }
 
 func TestS2AHalfConnectionUpdateKey(t *testing.T) {
-
+	for _, tc := range []struct {
+		ciphersuite                                      s2a_proto.Ciphersuite
+		trafficSecret, expectedTrafficSecret, key, nonce []byte
+	}{
+		{
+			ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret:         testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			expectedTrafficSecret: testutil.Dehex("f38b9455ea5871235a69fc37610c6ca1215779e66b45a047d7390111e00081c4"),
+			key:                   testutil.Dehex("07dfdfca2fc3f015b6e51e579679b503"),
+			nonce:                 testutil.Dehex("79fdebc61b5fb9d9a34d9406"),
+		},
+		{
+			ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret:         testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			expectedTrafficSecret: testutil.Dehex("016c835db664beb5526a9bb3d9a4fba63e67255dcfa460a114d9f1ef9a9a1f685a518739f557d0e66fdb89bdafa26257"),
+			key:                   testutil.Dehex("4ee0f141c9a497a1db6f1ee0995248e804406fe39f35bcdff9f386048108bef1"),
+			nonce:                 testutil.Dehex("90f241fbc9f9f55100168d8b"),
+		},
+		{
+			ciphersuite:           s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret:         testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			expectedTrafficSecret: testutil.Dehex("f38b9455ea5871235a69fc37610c6ca1215779e66b45a047d7390111e00081c4"),
+			key:                   testutil.Dehex("18b61f93ee2d927d2f478f2220409738affb0092602d0812c96b965323e30878"),
+			nonce:                 testutil.Dehex("79fdebc61b5fb9d9a34d9406"),
+		},
+	} {
+		t.Run(tc.ciphersuite.String(), func(t *testing.T) {
+			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
+			if err != nil {
+				t.Fatalf("NewHalfConn(%v, %v) failed, err = %v", tc.ciphersuite, tc.trafficSecret, err)
+			}
+			if err := hc.UpdateKey(); err != nil {
+				t.Fatalf("hc.updateKey() failed, err = %v", err)
+			}
+			if got, want := hc.trafficSecret, tc.expectedTrafficSecret; !bytes.Equal(got, want) {
+				t.Errorf("updated traffic secret = %v, want %v", got, want)
+			}
+			if got, want := hc.key, tc.key; !bytes.Equal(got, want) {
+				t.Errorf("updated key = %v, want %v", got, want)
+			}
+			if got, want := hc.nonce, tc.nonce; !bytes.Equal(got, want) {
+				t.Errorf("updated nonce = %v, want %v", got, want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Added the initial S2A Half Connection. This is largely unimplemented, but exposes the basic methods that S2A Half Connection would provide. This also implements `expandLabel` specified in https://tools.ietf.org/html/rfc8446#section-7.1. It basically constructs a HkdfLabel struct (Which is a struct specific to TLS 1.3) and passes that to the underlying HKDF expand function.

One thing that became apparent when implementing `expandLabel` was that calling `h().Size()` is expensive. For example, `h` that is passed in will most likely be something like `sha256.New`. When we call `h()`, we are calling `sha256.New()` and creating a new Hash just to get the length. I think this is quite expensive when all we want is the length of the hash. We are doing this in both `expandLabel` as well as the underlying `expand` function. I think it may actually be worthwhile to bring back the `length` field in the expand interface for the underlying HKDF expander since we call `hash().Size()` here already. Either that, or just create a `hashLength` constant somewhere and hardcode the length, and then specify in the function documentation that the hashing function *must* return a hash of a certain length. WDYT?

Also, I'm not sure if `S2AHalfConnection` will be used outside of this package. I've exported it for now. Please let me know if it needs to be unexported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/14)
<!-- Reviewable:end -->
