### PR TITLE
Add length parameter to expand

### DIFF
--- a/security/s2a/internal/crypter/expander.go
+++ b/security/s2a/internal/crypter/expander.go
@@ -10,9 +10,9 @@ import (
 // https://tools.ietf.org/html/rfc5869 for details. It's use in TLS 1.3 is
 // specified in https://tools.ietf.org/html/rfc8446#section-7.2
 type hkdfExpander interface {
-	// expand takes a hashing function, a secret, a label, and returns the
-	// resulting expanded key.
-	expand(h func() hash.Hash, secret, label []byte) ([]byte, error)
+	// expand takes a hashing function, a secret, a label, and the output length
+	// in bytes, and returns the resulting expanded key.
+	expand(h func() hash.Hash, secret, label []byte, length int) ([]byte, error)
 }
 
 // defaultHKDFExpander is the default HKDF expander which uses Go's crypto/hkdf
@@ -24,8 +24,7 @@ func newDefaultHKDFExpander() hkdfExpander {
 	return &defaultHKDFExpander{}
 }
 
-func (*defaultHKDFExpander) expand(h func() hash.Hash, secret, label []byte) ([]byte, error) {
-	length := h().Size()
+func (*defaultHKDFExpander) expand(h func() hash.Hash, secret, label []byte, length int) ([]byte, error) {
 	outBuf := make([]byte, length)
 	n, err := hkdf.Expand(h, secret, label).Read(outBuf)
 	if err != nil {

--- a/security/s2a/internal/crypter/expander_test.go
+++ b/security/s2a/internal/crypter/expander_test.go
@@ -9,12 +9,8 @@ import (
 
 func TestExpand(t *testing.T) {
 	// The following test vectors were taken from
-	// https://tools.ietf.org/html/rfc5869. Note have vectors have
-	// been slightly modified to test our specific implementation. In
-	// particular, the output has been truncated to a specific length since our
-	// implementation doesn't take `length` as a parameter and the output length
-	// is determined by the hash. Also note that `prk` and `okm` mentioned in
-	// the RFC have been renamed to `secret` and `out`.
+	// https://tools.ietf.org/html/rfc5869. Note that `prk` and `okm`
+	// mentioned in the RFC have been renamed to `secret` and `out`.
 	for _, tc := range []struct {
 		desc              string
 		secret, info, out []byte
@@ -24,28 +20,31 @@ func TestExpand(t *testing.T) {
 			desc:   "sha256 basic",
 			secret: testutil.Dehex("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"),
 			info:   testutil.Dehex("f0f1f2f3f4f5f6f7f8f9"),
-			out:    testutil.Dehex("3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf"),
+			out:    testutil.Dehex("3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"),
+			length: 42,
 		},
 		{
 			desc:   "sha256 longer input/output",
 			secret: testutil.Dehex("06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"),
 			info:   testutil.Dehex("b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"),
-			out:    testutil.Dehex("b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c"),
+			out:    testutil.Dehex("b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"),
+			length: 82,
 		},
 		{
 			desc:   "sha256 zero length info",
 			secret: testutil.Dehex("19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04"),
-			out:    testutil.Dehex("8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d"),
+			out:    testutil.Dehex("8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"),
+			length: 42,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			expander := newDefaultHKDFExpander()
-			got, err := expander.expand(sha256.New, tc.secret, tc.info)
+			got, err := expander.expand(sha256.New, tc.secret, tc.info, tc.length)
 			if err != nil {
 				t.Errorf("expand failed with error: %v", err)
 			}
 			if !bytes.Equal(got, tc.out) {
-				t.Errorf("expand(sha256.New, %v, %v) = %v, want %v.", tc.secret, tc.info, got, tc.out)
+				t.Errorf("expand(sha256.New, %v, %v, %v) = %v, want %v.", tc.secret, tc.info, tc.length, got, tc.out)
 			}
 		})
 	}


### PR DESCRIPTION
After working on the Half Connection, I realized that the length parameter is actually necessary. We don't always want the output length to be the size of the hash. Rather, we want to be able to specify the output size. For example, we use this function to generate the key for the AES-GCM crypters. If we want to generate a key for AES-GCM128SHA256, we need a 16 byte key (128 bits) and if we want to generate a key for AES-GCM256SHA384, we need a 32 byte key (256 bits). If we use `hash.Size()` like we were doing before, the output length would be different from our desired length. For AES-GCM128SHA256, it would be 32 bytes and for AES-GCM256SHA384, it would be 48 bytes.

This PR adds back the length parameter so that we can specify the output size depending on what kind of key we're generating.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/20)
<!-- Reviewable:end -->
