### PR TITLE
Add S2A record protocol structure

### DIFF
--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -32,7 +32,7 @@ type S2AHalfConnection struct {
 
 // NewHalfConn creates a new instance of S2AHalfConnection given a ciphersuite
 // and a traffic secret.
-func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte) (*S2AHalfConnection, error) {
+func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, sequence uint64) (*S2AHalfConnection, error) {
 	cs, err := newCiphersuite(ciphersuite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new ciphersuite: %v", ciphersuite)
@@ -41,7 +41,7 @@ func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte) (*S2AHalfC
 		return nil, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
 	}
 
-	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(0), trafficSecret: trafficSecret}
+	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(sequence), trafficSecret: trafficSecret}
 	if err = hc.updateCrypterAndNonce(hc.trafficSecret); err != nil {
 		return nil, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
 	}

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -32,7 +32,7 @@ type S2AHalfConnection struct {
 
 // NewHalfConn creates a new instance of S2AHalfConnection given a ciphersuite
 // and a traffic secret.
-func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, sequence uint64) (*S2AHalfConnection, error) {
+func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte) (*S2AHalfConnection, error) {
 	cs, err := newCiphersuite(ciphersuite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new ciphersuite: %v", ciphersuite)
@@ -41,7 +41,7 @@ func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, sequence u
 		return nil, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
 	}
 
-	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(sequence), trafficSecret: trafficSecret}
+	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(0), trafficSecret: trafficSecret}
 	if err = hc.updateCrypterAndNonce(hc.trafficSecret); err != nil {
 		return nil, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
 	}

--- a/security/s2a/internal/crypter/record.go
+++ b/security/s2a/internal/crypter/record.go
@@ -10,18 +10,18 @@ import (
 const (
 	// TODO(rnkim): Add more documentation around where these values come from.
 	// s2aRecordMaxPlaintextSize is the maximum size of an S2A record message.
-	s2aRecordMaxPlaintextSize = 16*1024 + 256
+	s2aRecordMaxPlaintextSize = 16384 // 2^14
 	// s2aRecordHeaderSize is the size of the record header in bytes.
 	s2aRecordHeaderSize = 5
 	// s2aRecordTypeSize is the size of the record type.
 	s2aRecordTypeSize = 1
-	// s2aWriteBufferInitialSize is the initial write buffer size.
-	s2aWriteBufferInitialSize = 32 * 1024
+	// s2aOutgoingRecordsBufInitialSize is the initial write buffer size.
+	s2aOutgoingRecordsBufInitialSize = 32 * 1024
 )
 
-// Conn represents a secured TLS connection. It implements the net.Conn
+// conn represents a secured TLS connection. It implements the net.Conn
 // interface.
-type Conn struct {
+type conn struct {
 	net.Conn
 	// inConnection is the half connection responsible for decrypting incoming
 	// bytes.
@@ -36,20 +36,20 @@ type Conn struct {
 	// decrypted. This data might not compose a complete record. It may consist
 	// of several records, the last of which could be incomplete.
 	unusedBytes []byte
-	// outgoingRecordsBuf is a buffer used to contain encrypted records before
-	// being written to the network.
+	// outgoingRecordsBuf is a buffer used to contain outgoing TLS records
+	// before they are written to the network.
 	outgoingRecordsBuf []byte
 	// nextRecord stores the next record info in the unusedBytes buffer.
 	nextRecord []byte
-	// overheadSize is the calculated overhead size of each record.
+	// overheadSize is the overhead size of each record.
 	overheadSize int
 	// handshakerServiceAddr stores the address of the S2A handshaker service.
 	handshakerServiceAddr string
 }
 
-// ConnOptions holds the options used for creating a new Conn object.
+// ConnOptions holds the options used for creating a new conn object.
 type ConnOptions struct {
-	c                                              net.Conn
+	netConn                                        net.Conn
 	ciphersuite                                    s2a_proto.Ciphersuite
 	tlsVersion                                     s2a_proto.TLSVersion
 	inTrafficSecret, outTrafficSecret, unusedBytes []byte
@@ -68,38 +68,31 @@ func NewConn(o *ConnOptions) (net.Conn, error) {
 
 	inConnection, err := NewHalfConn(o.ciphersuite, o.inTrafficSecret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create input half connection: %v", err)
+		return nil, fmt.Errorf("failed to create inbound half connection: %v", err)
 	}
 	outConnection, err := NewHalfConn(o.ciphersuite, o.outTrafficSecret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create output half connection: %v", err)
+		return nil, fmt.Errorf("failed to create outbound half connection: %v", err)
 	}
 
 	// TODO(rnkim): Add TagSize() to Half Connection? The code below won't work
 	// once we move HalfConn into it's own directory.
+	// Note: The tag size for the in/out connections should be the same.
+	// The inConnection was arbitrarily chosen below.
 	overheadSize := s2aRecordHeaderSize + s2aRecordTypeSize + inConnection.aeadCrypter.tagSize()
 	var unusedBytesBuf []byte
-	if o.unusedBytes == nil {
-		// We pre-allocate unusedBytes to be of size
-		// 2*s2aRecordMaxPlaintextSize-1 during initialization. We only
-		// read from the network into unusedBytes when unusedBytes does not
-		// contain a complete record, which is at most
-		// s2aRecordMaxPlaintextSize-1 (bytes). And we read at most
-		// s2aRecordMaxPlaintextSize (bytes) data into unusedBytes at one
-		// time. Therefore, 2*s2aRecordMaxPlaintextSize-1 is large enough
-		// to buffer data read from the network.
-		unusedBytesBuf = make([]byte, 0, 2*s2aRecordMaxPlaintextSize-1)
-	} else {
+	// TODO(gud): Potentially optimize unusedBytesBuf with pre-allocation.
+	if o.unusedBytes != nil {
 		unusedBytesBuf = make([]byte, len(o.unusedBytes))
 		copy(unusedBytesBuf, o.unusedBytes)
 	}
 
-	s2aConn := &Conn{
-		Conn:                  o.c,
+	s2aConn := &conn{
+		Conn:                  o.netConn,
 		inConnection:          inConnection,
 		outConnection:         outConnection,
 		unusedBytes:           unusedBytesBuf,
-		outgoingRecordsBuf:    make([]byte, s2aWriteBufferInitialSize),
+		outgoingRecordsBuf:    make([]byte, s2aOutgoingRecordsBufInitialSize),
 		nextRecord:            unusedBytesBuf,
 		overheadSize:          overheadSize,
 		handshakerServiceAddr: o.handshakerServiceAddr,
@@ -107,12 +100,12 @@ func NewConn(o *ConnOptions) (net.Conn, error) {
 	return s2aConn, nil
 }
 
-func (p *Conn) Read(b []byte) (n int, err error) {
+func (p *conn) Read(b []byte) (n int, err error) {
 	// TODO: Implement this.
 	panic("Read unimplemented")
 }
 
-func (p *Conn) Write(b []byte) (n int, err error) {
+func (p *conn) Write(b []byte) (n int, err error) {
 	// TODO: Implement this.
 	panic("Write unimplemented")
 }

--- a/security/s2a/internal/crypter/record.go
+++ b/security/s2a/internal/crypter/record.go
@@ -20,98 +20,95 @@ const (
 	// tlsRecordTypeSize is the size in bytes of the TLS 1.3 record type.
 	tlsRecordTypeSize = 1
 	// TODO(gud): Revisit what initial size to use when implementating Write.
-	// s2aOutgoingRecordsBufInitialSize is the initial write buffer size in
-	// bytes.
-	s2aOutgoingRecordsBufInitialSize = 32 * 1024
+	// outBufSize is the initial write buffer size in bytes.
+	outBufSize = 32 * 1024
 )
 
 // conn represents a secured TLS connection. It implements the net.Conn
 // interface.
 type conn struct {
 	net.Conn
-	// inConnection is the half connection responsible for decrypting incoming
-	// bytes.
-	inConnection *S2AHalfConnection
-	// outConnection is the half connection responsible for encrypting outgoing
-	// bytes.
-	outConnection *S2AHalfConnection
+	// inConn is the half connection responsible for decrypting incoming bytes.
+	inConn *S2AHalfConnection
+	// outConn is the half connection responsible for encrypting outgoing bytes.
+	outConn *S2AHalfConnection
 	// pendingApplicationData holds data that has been read from the connection
 	// and decrypted, but has not yet been returned by Read.
 	pendingApplicationData []byte
-	// unusedBytes holds data read from the network that has not yet been
+	// unusedBuf holds data read from the network that has not yet been
 	// decrypted. This data might not consist of a complete record. It may
 	// consist of several records, the last of which could be incomplete.
-	unusedBytes []byte
-	// outgoingRecordsBuf is a buffer used to contain outgoing TLS records
-	// before they are written to the network.
-	outgoingRecordsBuf []byte
-	// nextRecord stores the next record info in the unusedBytes buffer.
+	unusedBuf []byte
+	// outRecordsBuf is a buffer used to contain outgoing TLS records before
+	// they are written to the network.
+	outRecordsBuf []byte
+	// nextRecord stores the next record info in the unusedBuf buffer.
 	nextRecord []byte
 	// overheadSize is the overhead size in bytes of each TLS 1.3 record, which
 	// is computed as overheadSize = header size + record type byte + tag size.
 	// Note that there is no padding by zeros in the overhead calculation.
 	overheadSize int
-	// handshakerServiceAddr stores the address of the S2A handshaker service.
-	handshakerServiceAddr string
+	// hsAddr stores the address of the S2A handshaker service.
+	hsAddr string
 }
 
 // ConnOptions holds the options used for creating a new conn object.
 type ConnOptions struct {
-	netConn                                        net.Conn
-	ciphersuite                                    s2apb.Ciphersuite
-	tlsVersion                                     s2apb.TLSVersion
-	inTrafficSecret, outTrafficSecret, unusedBytes []byte
+	netConn                                      net.Conn
+	ciphersuite                                  s2apb.Ciphersuite
+	tlsVersion                                   s2apb.TLSVersion
+	inTrafficSecret, outTrafficSecret, unusedBuf []byte
 	// TODO(rnkim): Add initial sequence number to half conneciton.
 	inSequence, outSequence uint64
-	handshakerServiceAddr   string
+	hsAddr                  string
 }
 
 func NewConn(o *ConnOptions) (net.Conn, error) {
 	if o == nil {
-		return nil, errors.New("conn options must be not nil")
+		return nil, errors.New("conn options must not be nil")
 	}
 	if o.tlsVersion != s2apb.TLSVersion_TLS1_3 {
 		return nil, errors.New("TLS version must be TLS 1.3")
 	}
 
-	inConnection, err := NewHalfConn(o.ciphersuite, o.inTrafficSecret)
+	inConn, err := NewHalfConn(o.ciphersuite, o.inTrafficSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create inbound half connection: %v", err)
 	}
-	outConnection, err := NewHalfConn(o.ciphersuite, o.outTrafficSecret)
+	outConn, err := NewHalfConn(o.ciphersuite, o.outTrafficSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create outbound half connection: %v", err)
 	}
 
 	// TODO(rnkim): Add TagSize() to Half Connection.
-	// Note: The tag size for the in/out connections should be the same.
-	overheadSize := tlsRecordHeaderSize + tlsRecordTypeSize + inConnection.aeadCrypter.tagSize()
-	var unusedBytesBuf []byte
-	// TODO(gud): Potentially optimize unusedBytesBuf with pre-allocation.
-	if o.unusedBytes != nil {
-		unusedBytesBuf = make([]byte, len(o.unusedBytes))
-		copy(unusedBytesBuf, o.unusedBytes)
+	// The tag size for the in/out connections should be the same.
+	overheadSize := tlsRecordHeaderSize + tlsRecordTypeSize + inConn.aeadCrypter.tagSize()
+	var unusedBuf []byte
+	// TODO(gud): Potentially optimize unusedBuf with pre-allocation.
+	if o.unusedBuf != nil {
+		unusedBuf = make([]byte, len(o.unusedBuf))
+		copy(unusedBuf, o.unusedBuf)
 	}
 
 	s2aConn := &conn{
-		Conn:                  o.netConn,
-		inConnection:          inConnection,
-		outConnection:         outConnection,
-		unusedBytes:           unusedBytesBuf,
-		outgoingRecordsBuf:    make([]byte, s2aOutgoingRecordsBufInitialSize),
-		nextRecord:            unusedBytesBuf,
-		overheadSize:          overheadSize,
-		handshakerServiceAddr: o.handshakerServiceAddr,
+		Conn:          o.netConn,
+		inConn:        inConn,
+		outConn:       outConn,
+		unusedBuf:     unusedBuf,
+		outRecordsBuf: make([]byte, outBufSize),
+		nextRecord:    unusedBuf,
+		overheadSize:  overheadSize,
+		hsAddr:        o.hsAddr,
 	}
 	return s2aConn, nil
 }
 
 func (p *conn) Read(b []byte) (n int, err error) {
 	// TODO: Implement this.
-	panic("Read unimplemented")
+	return 0, errors.New("read unimplemented")
 }
 
 func (p *conn) Write(b []byte) (n int, err error) {
 	// TODO: Implement this.
-	panic("Write unimplemented")
+	return 0, errors.New("write unimplemented")
 }

--- a/security/s2a/internal/crypter/record.go
+++ b/security/s2a/internal/crypter/record.go
@@ -1,0 +1,118 @@
+package crypter
+
+import (
+	"errors"
+	"fmt"
+	s2a_proto "google.golang.org/grpc/security/s2a/internal/proto"
+	"net"
+)
+
+const (
+	// TODO(rnkim): Add more documentation around where these values come from.
+	// s2aRecordMaxPlaintextSize is the maximum size of an S2A record message.
+	s2aRecordMaxPlaintextSize = 16*1024 + 256
+	// s2aRecordHeaderSize is the size of the record header in bytes.
+	s2aRecordHeaderSize = 5
+	// s2aRecordTypeSize is the size of the record type.
+	s2aRecordTypeSize = 1
+	// s2aWriteBufferInitialSize is the initial write buffer size.
+	s2aWriteBufferInitialSize = 32 * 1024
+)
+
+// Conn represents a secured TLS connection. It implements the net.Conn
+// interface.
+type Conn struct {
+	net.Conn
+	// inConnection is the half connection responsible for decrypting incoming
+	// bytes.
+	inConnection S2AHalfConnection
+	// outConnection is the half connection responsible for encrypting outgoing
+	// bytes.
+	outConnection S2AHalfConnection
+	// pendingApplicationData holds data that has been read from the connection
+	// and decrypted, but has not yet been returned by Read.
+	pendingApplicationData []byte
+	// unusedBytes holds data read from the network that has not yet been
+	// decrypted. This data might not compose a complete record. It may consist
+	// of several records, the last of which could be incomplete.
+	unusedBytes []byte
+	// outgoingRecordsBuf is a buffer used to contain encrypted records before
+	// being written to the network.
+	outgoingRecordsBuf []byte
+	// nextRecord stores the next record info in the unusedBytes buffer.
+	nextRecord []byte
+	// overheadSize is the calculated overhead size of each record.
+	overheadSize int
+	// handshakerServiceAddr stores the address of the S2A handshaker service.
+	handshakerServiceAddr string
+}
+
+// ConnOptions holds the options used for creating a new Conn object.
+type ConnOptions struct {
+	c                                              net.Conn
+	ciphersuite                                    s2a_proto.Ciphersuite
+	tlsVersion                                     s2a_proto.TLSVersion
+	inTrafficSecret, outTrafficSecret, unusedBytes []byte
+	// TODO(rnkim): Pass these to HalfConn constructor.
+	inSequence, outSequence uint64
+	handshakerServiceAddr   string
+}
+
+func NewConn(o *ConnOptions) (net.Conn, error) {
+	if o == nil {
+		return nil, errors.New("conn options must be not nil")
+	}
+	if o.tlsVersion != s2a_proto.TLSVersion_TLS1_3 {
+		return nil, errors.New("TLS version must be TLS 1.3")
+	}
+
+	inConnection, err := NewHalfConn(o.ciphersuite, o.inTrafficSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create input half connection: %v", err)
+	}
+	outConnection, err := NewHalfConn(o.ciphersuite, o.outTrafficSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create output half connection: %v", err)
+	}
+
+	// TODO(rnkim): Add TagSize() to Half Connection? The code below won't work
+	// once we move HalfConn into it's own directory.
+	overheadSize := s2aRecordHeaderSize + s2aRecordTypeSize + inConnection.aeadCrypter.tagSize()
+	var unusedBytesBuf []byte
+	if o.unusedBytes == nil {
+		// We pre-allocate unusedBytes to be of size
+		// 2*s2aRecordMaxPlaintextSize-1 during initialization. We only
+		// read from the network into unusedBytes when unusedBytes does not
+		// contain a complete record, which is at most
+		// s2aRecordMaxPlaintextSize-1 (bytes). And we read at most
+		// s2aRecordMaxPlaintextSize (bytes) data into unusedBytes at one
+		// time. Therefore, 2*s2aRecordMaxPlaintextSize-1 is large enough
+		// to buffer data read from the network.
+		unusedBytesBuf = make([]byte, 0, 2*s2aRecordMaxPlaintextSize-1)
+	} else {
+		unusedBytesBuf = make([]byte, len(o.unusedBytes))
+		copy(unusedBytesBuf, o.unusedBytes)
+	}
+
+	s2aConn := &Conn{
+		Conn:                  o.c,
+		inConnection:          inConnection,
+		outConnection:         outConnection,
+		unusedBytes:           unusedBytesBuf,
+		outgoingRecordsBuf:    make([]byte, s2aWriteBufferInitialSize),
+		nextRecord:            unusedBytesBuf,
+		overheadSize:          overheadSize,
+		handshakerServiceAddr: o.handshakerServiceAddr,
+	}
+	return s2aConn, nil
+}
+
+func (p *Conn) Read(b []byte) (n int, err error) {
+	// TODO: Implement this.
+	panic("Read unimplemented")
+}
+
+func (p *Conn) Write(b []byte) (n int, err error) {
+	// TODO: Implement this.
+	panic("Write unimplemented")
+}

--- a/security/s2a/internal/crypter/record.go
+++ b/security/s2a/internal/crypter/record.go
@@ -61,8 +61,9 @@ type ConnOptions struct {
 	ciphersuite                                    s2apb.Ciphersuite
 	tlsVersion                                     s2apb.TLSVersion
 	inTrafficSecret, outTrafficSecret, unusedBytes []byte
-	inSequence, outSequence                        uint64
-	handshakerServiceAddr                          string
+	// TODO(rnkim): Add initial sequence number to half conneciton.
+	inSequence, outSequence uint64
+	handshakerServiceAddr   string
 }
 
 func NewConn(o *ConnOptions) (net.Conn, error) {
@@ -73,11 +74,11 @@ func NewConn(o *ConnOptions) (net.Conn, error) {
 		return nil, errors.New("TLS version must be TLS 1.3")
 	}
 
-	inConnection, err := NewHalfConn(o.ciphersuite, o.inTrafficSecret, o.inSequence)
+	inConnection, err := NewHalfConn(o.ciphersuite, o.inTrafficSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create inbound half connection: %v", err)
 	}
-	outConnection, err := NewHalfConn(o.ciphersuite, o.outTrafficSecret, o.outSequence)
+	outConnection, err := NewHalfConn(o.ciphersuite, o.outTrafficSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create outbound half connection: %v", err)
 	}

--- a/security/s2a/internal/crypter/record.go
+++ b/security/s2a/internal/crypter/record.go
@@ -8,19 +8,20 @@ import (
 )
 
 const (
-	// The TLS constants below (tlsRecordMaxPlaintextSize, tlsRecordHeaderSize,
-	// tlsRecordTypeSize) were taken from
+	// The TLS 1.3-specific constants below (tlsRecordMaxPlaintextSize,
+	// tlsRecordHeaderSize, tlsRecordTypeSize) were taken from
 	// https://tools.ietf.org/html/rfc8446#section-5.1
 
-	// tlsRecordMaxPlaintextSize is the maximum size of the plaintext in a
-	// single TLS 1.3 record.
+	// tlsRecordMaxPlaintextSize is the maximum size in bytes of the plaintext
+	// in a single TLS 1.3 record.
 	tlsRecordMaxPlaintextSize = 16384 // 2^14
-	// tlsRecordHeaderSize is the size of the record header in bytes.
+	// tlsRecordHeaderSize is the size in bytes of the TLS 1.3 record header.
 	tlsRecordHeaderSize = 5
-	// tlsRecordTypeSize is the size of the record type.
+	// tlsRecordTypeSize is the size in bytes of the TLS 1.3 record type.
 	tlsRecordTypeSize = 1
 	// TODO(gud): Revisit what initial size to use when implementating Write.
-	// s2aOutgoingRecordsBufInitialSize is the initial write buffer size.
+	// s2aOutgoingRecordsBufInitialSize is the initial write buffer size in
+	// bytes.
 	s2aOutgoingRecordsBufInitialSize = 32 * 1024
 )
 
@@ -46,8 +47,9 @@ type conn struct {
 	outgoingRecordsBuf []byte
 	// nextRecord stores the next record info in the unusedBytes buffer.
 	nextRecord []byte
-	// overheadSize is the overhead size of each TLS 1.3 record.
-	// overheadSize = header size + record type byte + tag size (no padding).
+	// overheadSize is the overhead size in bytes of each TLS 1.3 record, which
+	// is computed as overheadSize = header size + record type byte + tag size.
+	// Note that there is no padding by zeros in the overhead calculation.
 	overheadSize int
 	// handshakerServiceAddr stores the address of the S2A handshaker service.
 	handshakerServiceAddr string

--- a/security/s2a/internal/crypter/record_test.go
+++ b/security/s2a/internal/crypter/record_test.go
@@ -23,7 +23,6 @@ func TestNewS2ARecordConn(t *testing.T) {
 	for _, tc := range []struct {
 		desc                     string
 		options                  *ConnOptions
-		outPayloadSizeLimit      int
 		outUnusedBytesBuf        []byte
 		outOverheadSize          int
 		outHandshakerServiceAddr string
@@ -70,7 +69,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 			outErr: true,
 		},
 		{
-			desc: "basic 1",
+			desc: "basic with AES-128-GCM-SHA256",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
@@ -79,12 +78,12 @@ func TestNewS2ARecordConn(t *testing.T) {
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
 			},
-			outPayloadSizeLimit:      2282,
+			// outOverheadSize = header size + record type byte + tag size.
 			outOverheadSize:          22,
 			outHandshakerServiceAddr: "test handshaker address",
 		},
 		{
-			desc: "basic 2",
+			desc: "basic with AES-256-GCM-SHA384",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
@@ -93,12 +92,26 @@ func TestNewS2ARecordConn(t *testing.T) {
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
 			},
-			outPayloadSizeLimit:      2282,
+			// outOverheadSize = header size + record type byte + tag size.
 			outOverheadSize:          22,
 			outHandshakerServiceAddr: "test handshaker address",
 		},
 		{
-			desc: "basic 3",
+			desc: "basic with CHACHA20-POLY1305-SHA256",
+			options: &ConnOptions{
+				netConn:               &fakeConn{},
+				ciphersuite:           s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
+				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				handshakerServiceAddr: "test handshaker address",
+			},
+			// outOverheadSize = header size + record type byte + tag size.
+			outOverheadSize:          22,
+			outHandshakerServiceAddr: "test handshaker address",
+		},
+		{
+			desc: "basic with unusedBytes",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
@@ -108,7 +121,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 				unusedBytes:           testutil.Dehex("ffffffff"),
 				handshakerServiceAddr: "test handshaker address",
 			},
-			outUnusedBytesBuf:        testutil.Dehex("ffffffff"),
+			outUnusedBytesBuf: testutil.Dehex("ffffffff"),
+			// outOverheadSize = header size + record type byte + tag size.
 			outOverheadSize:          22,
 			outHandshakerServiceAddr: "test handshaker address",
 		},

--- a/security/s2a/internal/crypter/record_test.go
+++ b/security/s2a/internal/crypter/record_test.go
@@ -36,7 +36,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 		{
 			desc: "invalid input traffic secret size",
 			options: &ConnOptions{
-				c:                     &fakeConn{},
+				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
 				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
@@ -48,7 +48,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 		{
 			desc: "invalid output traffic secret size",
 			options: &ConnOptions{
-				c:                     &fakeConn{},
+				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
 				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
@@ -60,7 +60,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 		{
 			desc: "invalid tls version",
 			options: &ConnOptions{
-				c:                     &fakeConn{},
+				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
 				tlsVersion:            s2a_proto.TLSVersion_TLS1_2,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
@@ -72,7 +72,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 		{
 			desc: "basic 1",
 			options: &ConnOptions{
-				c:                     &fakeConn{},
+				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
 				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
@@ -86,7 +86,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 		{
 			desc: "basic 2",
 			options: &ConnOptions{
-				c:                     &fakeConn{},
+				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
 				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
@@ -100,7 +100,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 		{
 			desc: "basic 3",
 			options: &ConnOptions{
-				c:                     &fakeConn{},
+				netConn:               &fakeConn{},
 				ciphersuite:           s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
 				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
@@ -119,7 +119,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				t.Errorf("NewConn(%v) = (err=nil) = %v, want %v", *tc.options, got, want)
 			}
 			if err == nil {
-				conn := netConn.(*Conn)
+				conn := netConn.(*conn)
 				if got, want := conn.unusedBytes, tc.outUnusedBytesBuf; !bytes.Equal(got, want) {
 					t.Errorf("conn.unusedBytes = %v, want %v", got, want)
 				}

--- a/security/s2a/internal/crypter/record_test.go
+++ b/security/s2a/internal/crypter/record_test.go
@@ -1,0 +1,135 @@
+package crypter
+
+import (
+	"bytes"
+	"google.golang.org/grpc/security/s2a/internal/crypter/testutil"
+	s2a_proto "google.golang.org/grpc/security/s2a/internal/proto"
+	"net"
+	"testing"
+)
+
+// fakeConn is a fake implementation of the net.Conn interface used for testing.
+type fakeConn struct {
+	net.Conn
+	in  bytes.Buffer
+	out bytes.Buffer
+}
+
+func (c *fakeConn) Read(b []byte) (n int, err error)  { return c.in.Read(b) }
+func (c *fakeConn) Write(b []byte) (n int, err error) { return c.out.Write(b) }
+func (c *fakeConn) Close() error                      { return nil }
+
+func TestNewS2ARecordConn(t *testing.T) {
+	for _, tc := range []struct {
+		desc                     string
+		options                  *ConnOptions
+		outPayloadSizeLimit      int
+		outUnusedBytesBuf        []byte
+		outOverheadSize          int
+		outHandshakerServiceAddr string
+		outErr                   bool
+	}{
+		{
+			desc:   "nil conn options",
+			outErr: true,
+		},
+		{
+			desc: "invalid input traffic secret size",
+			options: &ConnOptions{
+				c:                     &fakeConn{},
+				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				handshakerServiceAddr: "test handshaker address",
+			},
+			outErr: true,
+		},
+		{
+			desc: "invalid output traffic secret size",
+			options: &ConnOptions{
+				c:                     &fakeConn{},
+				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				handshakerServiceAddr: "test handshaker address",
+			},
+			outErr: true,
+		},
+		{
+			desc: "invalid tls version",
+			options: &ConnOptions{
+				c:                     &fakeConn{},
+				ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
+				tlsVersion:            s2a_proto.TLSVersion_TLS1_2,
+				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				handshakerServiceAddr: "test handshaker address",
+			},
+			outErr: true,
+		},
+		{
+			desc: "basic 1",
+			options: &ConnOptions{
+				c:                     &fakeConn{},
+				ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
+				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				handshakerServiceAddr: "test handshaker address",
+			},
+			outPayloadSizeLimit:      2282,
+			outOverheadSize:          22,
+			outHandshakerServiceAddr: "test handshaker address",
+		},
+		{
+			desc: "basic 2",
+			options: &ConnOptions{
+				c:                     &fakeConn{},
+				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				handshakerServiceAddr: "test handshaker address",
+			},
+			outPayloadSizeLimit:      2282,
+			outOverheadSize:          22,
+			outHandshakerServiceAddr: "test handshaker address",
+		},
+		{
+			desc: "basic 3",
+			options: &ConnOptions{
+				c:                     &fakeConn{},
+				ciphersuite:           s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
+				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				unusedBytes:           testutil.Dehex("ffffffff"),
+				handshakerServiceAddr: "test handshaker address",
+			},
+			outUnusedBytesBuf:        testutil.Dehex("ffffffff"),
+			outOverheadSize:          22,
+			outHandshakerServiceAddr: "test handshaker address",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			netConn, err := NewConn(tc.options)
+			if got, want := err == nil, !tc.outErr; got != want {
+				t.Errorf("NewConn(%v) = (err=nil) = %v, want %v", *tc.options, got, want)
+			}
+			if err == nil {
+				conn := netConn.(*Conn)
+				if got, want := conn.unusedBytes, tc.outUnusedBytesBuf; !bytes.Equal(got, want) {
+					t.Errorf("conn.unusedBytes = %v, want %v", got, want)
+				}
+				if got, want := conn.overheadSize, tc.outOverheadSize; got != want {
+					t.Errorf("conn.overheadSize = %v, want %v", got, want)
+				}
+				if got, want := conn.handshakerServiceAddr, tc.outHandshakerServiceAddr; got != want {
+					t.Errorf("conn.handshakerServiceAddr = %v, want %v", got, want)
+				}
+			}
+		})
+	}
+}

--- a/security/s2a/internal/crypter/record_test.go
+++ b/security/s2a/internal/crypter/record_test.go
@@ -3,7 +3,7 @@ package crypter
 import (
 	"bytes"
 	"google.golang.org/grpc/security/s2a/internal/crypter/testutil"
-	s2a_proto "google.golang.org/grpc/security/s2a/internal/proto"
+	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
 	"net"
 	"testing"
 )
@@ -36,8 +36,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 			desc: "invalid input traffic secret size",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
-				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
-				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				ciphersuite:           s2apb.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:            s2apb.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
@@ -48,8 +48,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 			desc: "invalid output traffic secret size",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
-				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
-				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				ciphersuite:           s2apb.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:            s2apb.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
@@ -60,8 +60,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 			desc: "invalid tls version",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
-				ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
-				tlsVersion:            s2a_proto.TLSVersion_TLS1_2,
+				ciphersuite:           s2apb.Ciphersuite_AES_128_GCM_SHA256,
+				tlsVersion:            s2apb.TLSVersion_TLS1_2,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
@@ -72,8 +72,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 			desc: "basic with AES-128-GCM-SHA256",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
-				ciphersuite:           s2a_proto.Ciphersuite_AES_128_GCM_SHA256,
-				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				ciphersuite:           s2apb.Ciphersuite_AES_128_GCM_SHA256,
+				tlsVersion:            s2apb.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
@@ -86,8 +86,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 			desc: "basic with AES-256-GCM-SHA384",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
-				ciphersuite:           s2a_proto.Ciphersuite_AES_256_GCM_SHA384,
-				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				ciphersuite:           s2apb.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:            s2apb.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
@@ -100,8 +100,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 			desc: "basic with CHACHA20-POLY1305-SHA256",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
-				ciphersuite:           s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
-				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				ciphersuite:           s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+				tlsVersion:            s2apb.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				handshakerServiceAddr: "test handshaker address",
@@ -114,8 +114,8 @@ func TestNewS2ARecordConn(t *testing.T) {
 			desc: "basic with unusedBytes",
 			options: &ConnOptions{
 				netConn:               &fakeConn{},
-				ciphersuite:           s2a_proto.Ciphersuite_CHACHA20_POLY1305_SHA256,
-				tlsVersion:            s2a_proto.TLSVersion_TLS1_3,
+				ciphersuite:           s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+				tlsVersion:            s2apb.TLSVersion_TLS1_3,
 				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				unusedBytes:           testutil.Dehex("ffffffff"),

--- a/security/s2a/internal/crypter/record_test.go
+++ b/security/s2a/internal/crypter/record_test.go
@@ -35,94 +35,98 @@ func TestNewS2ARecordConn(t *testing.T) {
 		{
 			desc: "invalid input traffic secret size",
 			options: &ConnOptions{
-				netConn:               &fakeConn{},
-				ciphersuite:           s2apb.Ciphersuite_AES_256_GCM_SHA384,
-				tlsVersion:            s2apb.TLSVersion_TLS1_3,
-				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				handshakerServiceAddr: "test handshaker address",
+				netConn:          &fakeConn{},
+				ciphersuite:      s2apb.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:       s2apb.TLSVersion_TLS1_3,
+				inTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				hsAddr:           "test handshaker address",
 			},
 			outErr: true,
 		},
 		{
 			desc: "invalid output traffic secret size",
 			options: &ConnOptions{
-				netConn:               &fakeConn{},
-				ciphersuite:           s2apb.Ciphersuite_AES_256_GCM_SHA384,
-				tlsVersion:            s2apb.TLSVersion_TLS1_3,
-				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				handshakerServiceAddr: "test handshaker address",
+				netConn:          &fakeConn{},
+				ciphersuite:      s2apb.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:       s2apb.TLSVersion_TLS1_3,
+				inTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				hsAddr:           "test handshaker address",
 			},
 			outErr: true,
 		},
 		{
 			desc: "invalid tls version",
 			options: &ConnOptions{
-				netConn:               &fakeConn{},
-				ciphersuite:           s2apb.Ciphersuite_AES_128_GCM_SHA256,
-				tlsVersion:            s2apb.TLSVersion_TLS1_2,
-				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				handshakerServiceAddr: "test handshaker address",
+				netConn:          &fakeConn{},
+				ciphersuite:      s2apb.Ciphersuite_AES_128_GCM_SHA256,
+				tlsVersion:       s2apb.TLSVersion_TLS1_2,
+				inTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				hsAddr:           "test handshaker address",
 			},
 			outErr: true,
 		},
 		{
 			desc: "basic with AES-128-GCM-SHA256",
 			options: &ConnOptions{
-				netConn:               &fakeConn{},
-				ciphersuite:           s2apb.Ciphersuite_AES_128_GCM_SHA256,
-				tlsVersion:            s2apb.TLSVersion_TLS1_3,
-				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				handshakerServiceAddr: "test handshaker address",
+				netConn:          &fakeConn{},
+				ciphersuite:      s2apb.Ciphersuite_AES_128_GCM_SHA256,
+				tlsVersion:       s2apb.TLSVersion_TLS1_3,
+				inTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				hsAddr:           "test handshaker address",
 			},
-			// outOverheadSize = header size + record type byte + tag size.
+			// outOverheadSize = header size (5) + record type byte (1) +
+			// tag size (16).
 			outOverheadSize:          22,
 			outHandshakerServiceAddr: "test handshaker address",
 		},
 		{
 			desc: "basic with AES-256-GCM-SHA384",
 			options: &ConnOptions{
-				netConn:               &fakeConn{},
-				ciphersuite:           s2apb.Ciphersuite_AES_256_GCM_SHA384,
-				tlsVersion:            s2apb.TLSVersion_TLS1_3,
-				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				handshakerServiceAddr: "test handshaker address",
+				netConn:          &fakeConn{},
+				ciphersuite:      s2apb.Ciphersuite_AES_256_GCM_SHA384,
+				tlsVersion:       s2apb.TLSVersion_TLS1_3,
+				inTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				hsAddr:           "test handshaker address",
 			},
-			// outOverheadSize = header size + record type byte + tag size.
+			// outOverheadSize = header size (5) + record type byte (1) +
+			// tag size (16).
 			outOverheadSize:          22,
 			outHandshakerServiceAddr: "test handshaker address",
 		},
 		{
 			desc: "basic with CHACHA20-POLY1305-SHA256",
 			options: &ConnOptions{
-				netConn:               &fakeConn{},
-				ciphersuite:           s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
-				tlsVersion:            s2apb.TLSVersion_TLS1_3,
-				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				handshakerServiceAddr: "test handshaker address",
+				netConn:          &fakeConn{},
+				ciphersuite:      s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+				tlsVersion:       s2apb.TLSVersion_TLS1_3,
+				inTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				hsAddr:           "test handshaker address",
 			},
-			// outOverheadSize = header size + record type byte + tag size.
+			// outOverheadSize = header size (5) + record type byte (1) +
+			// tag size (16).
 			outOverheadSize:          22,
 			outHandshakerServiceAddr: "test handshaker address",
 		},
 		{
 			desc: "basic with unusedBytes",
 			options: &ConnOptions{
-				netConn:               &fakeConn{},
-				ciphersuite:           s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
-				tlsVersion:            s2apb.TLSVersion_TLS1_3,
-				inTrafficSecret:       testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				outTrafficSecret:      testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				unusedBytes:           testutil.Dehex("ffffffff"),
-				handshakerServiceAddr: "test handshaker address",
+				netConn:          &fakeConn{},
+				ciphersuite:      s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+				tlsVersion:       s2apb.TLSVersion_TLS1_3,
+				inTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				outTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+				unusedBuf:        testutil.Dehex("ffffffff"),
+				hsAddr:           "test handshaker address",
 			},
 			outUnusedBytesBuf: testutil.Dehex("ffffffff"),
-			// outOverheadSize = header size + record type byte + tag size.
+			// outOverheadSize = header size (5) + record type byte (1) +
+			// tag size (16).
 			outOverheadSize:          22,
 			outHandshakerServiceAddr: "test handshaker address",
 		},
@@ -132,18 +136,33 @@ func TestNewS2ARecordConn(t *testing.T) {
 			if got, want := err == nil, !tc.outErr; got != want {
 				t.Errorf("NewConn(%v) = (err=nil) = %v, want %v", *tc.options, got, want)
 			}
-			if err == nil {
-				conn := netConn.(*conn)
-				if got, want := conn.unusedBytes, tc.outUnusedBytesBuf; !bytes.Equal(got, want) {
-					t.Errorf("conn.unusedBytes = %v, want %v", got, want)
-				}
-				if got, want := conn.overheadSize, tc.outOverheadSize; got != want {
-					t.Errorf("conn.overheadSize = %v, want %v", got, want)
-				}
-				if got, want := conn.handshakerServiceAddr, tc.outHandshakerServiceAddr; got != want {
-					t.Errorf("conn.handshakerServiceAddr = %v, want %v", got, want)
-				}
+			if err != nil {
+				return
+			}
+			conn := netConn.(*conn)
+			if got, want := conn.unusedBuf, tc.outUnusedBytesBuf; !bytes.Equal(got, want) {
+				t.Errorf("conn.unusedBytes = %v, want %v", got, want)
+			}
+			if got, want := conn.overheadSize, tc.outOverheadSize; got != want {
+				t.Errorf("conn.overheadSize = %v, want %v", got, want)
+			}
+			if got, want := conn.hsAddr, tc.outHandshakerServiceAddr; got != want {
+				t.Errorf("conn.hsAddr = %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func TestConnRead(t *testing.T) {
+	conn := &conn{}
+	if _, err := conn.Read(nil); err == nil {
+		t.Errorf("read is unimplemented")
+	}
+}
+
+func TestConnWrite(t *testing.T) {
+	conn := &conn{}
+	if _, err := conn.Write(nil); err == nil {
+		t.Errorf("write is unimplemented")
 	}
 }


### PR DESCRIPTION
Added the S2A record protocol structure. `Read` and `Write` have been left unimplemented for now and will be completed in following PRs.

I've left some TODOs regarding the HalfConn constructor and API. There needs to be some updates to the `HalfConn` API as well as the counter API.

In particular:
- the `HalfConn` constructor needs to take a sequence number
- the counter constructor needs to take an initial value
- I think `HalfConn` needs a `TagSize` API. We can't retrieve the tag size from the AEAD crypter API since the `aeadCrypter` field is private in `HalfConn`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/29)
<!-- Reviewable:end -->
