### PR TITLE
Add initial value to counter constructor

### DIFF
--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -8,6 +8,7 @@ type counter struct {
 	hasOverflowed bool
 }
 
+// newCounter creates a new counter with the initial value set to val.
 func newCounter(val uint64) counter {
 	return counter{val: val}
 }

--- a/security/s2a/internal/crypter/counter.go
+++ b/security/s2a/internal/crypter/counter.go
@@ -8,8 +8,8 @@ type counter struct {
 	hasOverflowed bool
 }
 
-func newCounter() counter {
-	return counter{}
+func newCounter(val uint64) counter {
+	return counter{val: val}
 }
 
 // value returns the current value of the counter.

--- a/security/s2a/internal/crypter/counter_test.go
+++ b/security/s2a/internal/crypter/counter_test.go
@@ -5,6 +5,16 @@ import (
 	"testing"
 )
 
+func TestNewCounter(t *testing.T) {
+	counter := newCounter(1)
+	if got, want := counter.val, uint64(1); got != want {
+		t.Errorf("counter.val = %v, want %v", got, want)
+	}
+	if got, want := counter.hasOverflowed, false; got != want {
+		t.Errorf("counter.hasOverflowed = %v, want %v", got, want)
+	}
+}
+
 func TestCounterInc(t *testing.T) {
 	for _, tc := range []struct {
 		desc                     string


### PR DESCRIPTION
Added the option to specify an initial value when constructing a `counter`. This may be required for the resumption work that will be implemented in S2A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/30)
<!-- Reviewable:end -->
