### PR TITLE
Remove UpdateKey API from AEAD crypter

### DIFF
--- a/security/s2a/internal/crypter/aeadcrypter.go
+++ b/security/s2a/internal/crypter/aeadcrypter.go
@@ -11,6 +11,4 @@ type s2aAeadCrypter interface {
 	decrypt(dst, ciphertext, nonce, aad []byte) ([]byte, error)
 	// tagSize returns the tag size in bytes.
 	tagSize() int
-	// updateKey updates the key used for encryption and decryption.
-	updateKey(key []byte) error
 }

--- a/security/s2a/internal/crypter/aesgcm_test.go
+++ b/security/s2a/internal/crypter/aesgcm_test.go
@@ -104,55 +104,12 @@ func TestAESGCMInvalidKeySize(t *testing.T) {
 	}
 }
 
-// Test update key for AES-GCM using a key with different size from the initial
-// key.
-func TestAESGCMKeySizeUpdate(t *testing.T) {
-	for _, tc := range []struct {
-		desc          string
-		updateKeySize int
-	}{
-		{"mismatch key size update", aes256GcmKeySize},
-		{"invalid key size update", 17},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			key := make([]byte, aes128GcmKeySize)
-			crypter, err := newAESGCM(key)
-			if err != nil {
-				t.Fatalf("newAESGCM(keySize=%v) failed, err: %v", aes128GcmKeySize, err)
-			}
-
-			// Update the key with a new one which is a different from the original.
-			newKey := make([]byte, tc.updateKeySize)
-			if err = crypter.updateKey(newKey); err == nil {
-				t.Fatal("updateKey should fail with invalid key size error")
-			}
-		})
-	}
-}
-
-// Test encrypt and decrypt on roundtrip messages for AES-GCM with and without
-// updating the keys.
+// Test encrypt and decrypt on roundtrip messages for AES-GCM.
 func TestAESGCMEncryptRoundtrip(t *testing.T) {
 	for _, keySize := range []int{aes128GcmKeySize, aes256GcmKeySize} {
 		t.Run(fmt.Sprintf("keySize=%d", keySize), func(t *testing.T) {
 			key := make([]byte, keySize)
 			sender, receiver := getGCMCryptoPair(key, t)
-
-			// Test encrypt/decrypt before updating the key.
-			testGCMEncryptRoundtrip(sender, receiver, t)
-
-			// Update the key with a new one which is different from the
-			// original.
-			newKey := make([]byte, keySize)
-			newKey[0] = '\xbd'
-			if err := sender.updateKey(newKey); err != nil {
-				t.Fatalf("sender updateKey failed with: %v", err)
-			}
-			if err := receiver.updateKey(newKey); err != nil {
-				t.Fatalf("receiver updateKey failed with: %v", err)
-			}
-
-			// Test encrypt/decrypt after updating the key.
 			testGCMEncryptRoundtrip(sender, receiver, t)
 		})
 	}

--- a/security/s2a/internal/crypter/chachapoly.go
+++ b/security/s2a/internal/crypter/chachapoly.go
@@ -33,10 +33,6 @@ const (
 // chachapoly is the struct that holds a CHACHA-POLY cipher for the S2A AEAD crypter.
 type chachapoly struct {
 	aead cipher.AEAD
-	// keySize stores the size of the key which was initially used. This
-	// is necessary to restrict key updates to the same key length as the
-	// initial key.
-	keySize int
 }
 
 // newChachaPoly creates a Chacha-Poly crypter instance. Note that the key must be
@@ -45,12 +41,11 @@ func newChachaPoly(key []byte) (s2aAeadCrypter, error) {
 	if len(key) != chacha20Poly1305KeySize {
 		return nil, fmt.Errorf("%d bytes, given: %d", chacha20Poly1305KeySize, len(key))
 	}
-	crypter := chachapoly{keySize: len(key)}
-	err := crypter.updateKey(key)
+	c, err := chacha20poly1305.New(key)
 	if err != nil {
 		return nil, err
 	}
-	return &crypter, err
+	return &chachapoly{aead: c}, nil
 }
 
 // encrypt is the encryption function. dst can contain bytes at the beginning of
@@ -68,16 +63,4 @@ func (s *chachapoly) decrypt(dst, ciphertext, nonce, aad []byte) ([]byte, error)
 
 func (s *chachapoly) tagSize() int {
 	return tagSize
-}
-
-func (s *chachapoly) updateKey(key []byte) error {
-	if s.keySize != len(key) {
-		return fmt.Errorf("supplied key must have same size as initial key: %d bytes", s.keySize)
-	}
-	c, err := chacha20poly1305.New(key)
-	if err != nil {
-		return err
-	}
-	s.aead = c
-	return nil
 }

--- a/security/s2a/internal/crypter/chachapoly_test.go
+++ b/security/s2a/internal/crypter/chachapoly_test.go
@@ -104,31 +104,6 @@ func TestChachaPolyInvalidKeySize(t *testing.T) {
 	}
 }
 
-// Test update key for Chacha-Poly using a key with different size from the initial
-// key.
-func TestChachaPolyKeySizeUpdate(t *testing.T) {
-	for _, tc := range []struct {
-		desc          string
-		updateKeySize int
-	}{
-		{"invalid key size update", 1 + chacha20Poly1305KeySize},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			key := make([]byte, chacha20Poly1305KeySize)
-			crypter, err := newChachaPoly(key)
-			if err != nil {
-				t.Fatalf("NewChachaPoly(keySize=%v) failed, err: %v", chacha20Poly1305KeySize, err)
-			}
-
-			// Update the key with a new one which is a different from the original.
-			newKey := make([]byte, tc.updateKeySize)
-			if err = crypter.updateKey(newKey); err == nil {
-				t.Fatal("UpdateKey should fail with invalid key size error")
-			}
-		})
-	}
-}
-
 // Test Encrypt/Decrypt using an invalid nonce size.
 func TestChachaPolyEncryptDecryptInvalidNonce(t *testing.T) {
 	key := make([]byte, chacha20Poly1305KeySize)
@@ -146,29 +121,12 @@ func TestChachaPolyEncryptDecryptInvalidNonce(t *testing.T) {
 	}
 }
 
-// Test encrypt and decrypt on roundtrip messages for Chacha-Poly with and without
-// updating the keys.
+// Test encrypt and decrypt on roundtrip messages for Chacha-Poly.
 func TestChachaPolyEncryptRoundtrip(t *testing.T) {
 	for _, keySize := range []int{chacha20Poly1305KeySize} {
 		t.Run(fmt.Sprintf("keySize=%d", keySize), func(t *testing.T) {
 			key := make([]byte, keySize)
 			sender, receiver := getChachaPolyCrypterPair(key, t)
-
-			// Test encrypt/decrypt before updating the key.
-			testChachaPolyEncryptRoundtrip(sender, receiver, t)
-
-			// Update the key with a new one which is different from the
-			// original.
-			newKey := make([]byte, keySize)
-			newKey[0] = '\xbd'
-			if err := sender.updateKey(newKey); err != nil {
-				t.Fatalf("sender UpdateKey failed with: %v", err)
-			}
-			if err := receiver.updateKey(newKey); err != nil {
-				t.Fatalf("receiver UpdateKey failed with: %v", err)
-			}
-
-			// Test encrypt/decrypt after updating the key.
 			testChachaPolyEncryptRoundtrip(sender, receiver, t)
 		})
 	}


### PR DESCRIPTION
Removed the `UpdateKey` API from the AEAD crypter interface. This is because we can't allow the AEAD crypter to be mutated while we encrypt/decrypt in the S2A Half Connection. Rather than calling `UpdateKey`, we can just create a new AEAD crypter and reassign it which circumvents the issue of mutating the AEAD crypter while encrypting and decrypting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/32)
<!-- Reviewable:end -->
