### PR TITLE
Remove hash function from HKDF expand API

### DIFF
--- a/security/s2a/internal/crypter/expander.go
+++ b/security/s2a/internal/crypter/expander.go
@@ -10,23 +10,26 @@ import (
 // https://tools.ietf.org/html/rfc5869 for details. It's use in TLS 1.3 is
 // specified in https://tools.ietf.org/html/rfc8446#section-7.2
 type hkdfExpander interface {
-	// expand takes a hashing function, a secret, a label, and the output length
-	// in bytes, and returns the resulting expanded key.
-	expand(h func() hash.Hash, secret, label []byte, length int) ([]byte, error)
+	// expand takes a secret, a label, and the output length in bytes, and
+	// returns the resulting expanded key.
+	expand(secret, label []byte, length int) ([]byte, error)
 }
 
 // defaultHKDFExpander is the default HKDF expander which uses Go's crypto/hkdf
 // for HKDF expansion.
-type defaultHKDFExpander struct{}
-
-// newDefaultHKDFExpander creates an instance of the default HKDF expander.
-func newDefaultHKDFExpander() hkdfExpander {
-	return &defaultHKDFExpander{}
+type defaultHKDFExpander struct {
+	h func() hash.Hash
 }
 
-func (*defaultHKDFExpander) expand(h func() hash.Hash, secret, label []byte, length int) ([]byte, error) {
+// newDefaultHKDFExpander creates an instance of the default HKDF expander
+// using the given hash function.
+func newDefaultHKDFExpander(h func() hash.Hash) hkdfExpander {
+	return &defaultHKDFExpander{h: h}
+}
+
+func (d *defaultHKDFExpander) expand(secret, label []byte, length int) ([]byte, error) {
 	outBuf := make([]byte, length)
-	n, err := hkdf.Expand(h, secret, label).Read(outBuf)
+	n, err := hkdf.Expand(d.h, secret, label).Read(outBuf)
 	if err != nil {
 		return nil, fmt.Errorf("hkdf.Expand.Read failed with error: %v", err)
 	}

--- a/security/s2a/internal/crypter/expander_test.go
+++ b/security/s2a/internal/crypter/expander_test.go
@@ -38,8 +38,8 @@ func TestExpand(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			expander := newDefaultHKDFExpander()
-			got, err := expander.expand(sha256.New, tc.secret, tc.info, tc.length)
+			expander := newDefaultHKDFExpander(sha256.New)
+			got, err := expander.expand(tc.secret, tc.info, tc.length)
 			if err != nil {
 				t.Errorf("expand failed with error: %v", err)
 			}

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"golang.org/x/crypto/cryptobyte"
 	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
-	"hash"
 	"sync"
 )
 
@@ -18,9 +17,7 @@ const (
 )
 
 type S2AHalfConnection struct {
-	cs ciphersuite
-	// TODO(rnkim): Add hash function to expander constructor.
-	h        func() hash.Hash
+	cs       ciphersuite
 	expander hkdfExpander
 	// mutex guards sequence, aeadCrypter, trafficSecret, and nonce.
 	mutex         sync.Mutex
@@ -41,7 +38,7 @@ func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, sequence u
 		return nil, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
 	}
 
-	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(sequence), trafficSecret: trafficSecret}
+	hc := &S2AHalfConnection{cs: cs, expander: &defaultHKDFExpander{cs.hashFunction()}, sequence: newCounter(sequence), trafficSecret: trafficSecret}
 	if err = hc.updateCrypterAndNonce(hc.trafficSecret); err != nil {
 		return nil, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
 	}
@@ -163,5 +160,5 @@ func (hc *S2AHalfConnection) deriveSecret(secret, label []byte, length int) ([]b
 	if err != nil {
 		return nil, fmt.Errorf("deriveSecret failed: %v", err)
 	}
-	return hc.expander.expand(hc.h, secret, hkdfLabelBytes, length)
+	return hc.expander.expand(secret, hkdfLabelBytes, length)
 }

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -38,7 +38,7 @@ func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, sequence u
 		return nil, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
 	}
 
-	hc := &S2AHalfConnection{cs: cs, expander: &defaultHKDFExpander{cs.hashFunction()}, sequence: newCounter(sequence), trafficSecret: trafficSecret}
+	hc := &S2AHalfConnection{cs: cs, expander: newDefaultHKDFExpander(cs.hashFunction()), sequence: newCounter(sequence), trafficSecret: trafficSecret}
 	if err = hc.updateCrypterAndNonce(hc.trafficSecret); err != nil {
 		return nil, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
 	}


### PR DESCRIPTION
Removed the hash function from the HKDF expander API and added it to the constructor instead. This should make the API a bit cleaner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/35)
<!-- Reviewable:end -->
