### PR TITLE
Add sequence number to NewHalfConn

### DIFF
--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -32,7 +32,7 @@ type S2AHalfConnection struct {
 
 // NewHalfConn creates a new instance of S2AHalfConnection given a ciphersuite
 // and a traffic secret.
-func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte) (*S2AHalfConnection, error) {
+func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, sequence uint64) (*S2AHalfConnection, error) {
 	cs, err := newCiphersuite(ciphersuite)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new ciphersuite: %v", ciphersuite)
@@ -41,7 +41,7 @@ func NewHalfConn(ciphersuite s2apb.Ciphersuite, trafficSecret []byte) (*S2AHalfC
 		return nil, fmt.Errorf("supplied traffic secret must be %v bytes, given: %v bytes", cs.trafficSecretSize(), len(trafficSecret))
 	}
 
-	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(0), trafficSecret: trafficSecret}
+	hc := &S2AHalfConnection{cs: cs, h: cs.hashFunction(), expander: &defaultHKDFExpander{}, sequence: newCounter(sequence), trafficSecret: trafficSecret}
 	if err = hc.updateCrypterAndNonce(hc.trafficSecret); err != nil {
 		return nil, fmt.Errorf("failed to create half connection using traffic secret: %v", err)
 	}

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -10,11 +10,11 @@ import (
 
 // getHalfConnPair returns a sender/receiver pair of S2A Half Connections.
 func getHalfConnPair(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, t *testing.T) (*S2AHalfConnection, *S2AHalfConnection) {
-	sender, err := NewHalfConn(ciphersuite, trafficSecret)
+	sender, err := NewHalfConn(ciphersuite, trafficSecret, 0 /* sequence */)
 	if err != nil {
 		t.Fatalf("sender side NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
 	}
-	receiver, err := NewHalfConn(ciphersuite, trafficSecret)
+	receiver, err := NewHalfConn(ciphersuite, trafficSecret, 0 /* sequence */)
 	if err != nil {
 		t.Fatalf("receiver side NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
 	}
@@ -248,7 +248,7 @@ func TestNewHalfConn(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
+			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret, 0 /* sequence */)
 			if got, want := err == nil, !tc.shouldFail; got != want {
 				t.Errorf("NewHalfConn(%v, %v)=(err=nil)=%v, want %v", tc.ciphersuite, tc.trafficSecret, got, want)
 			}
@@ -333,7 +333,7 @@ func TestS2AHalfConnectionUpdateKey(t *testing.T) {
 		},
 	} {
 		t.Run(tc.ciphersuite.String(), func(t *testing.T) {
-			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret)
+			hc, err := NewHalfConn(tc.ciphersuite, tc.trafficSecret, 0 /* sequence */)
 			if err != nil {
 				t.Fatalf("NewHalfConn(%v, %v) failed: %v", tc.ciphersuite, tc.trafficSecret, err)
 			}


### PR DESCRIPTION
Added the sequence number to `NewHalfConn` to allow the record protocol to pass the initial sequence number to the half connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/38)
<!-- Reviewable:end -->
