### PR TITLE
Add TagSize API to the Half Connection

### DIFF
--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -100,7 +100,7 @@ func (hc *S2AHalfConnection) UpdateKey() error {
 	return nil
 }
 
-// TagSize returns the tag size of the underlying AEAD crypter.
+// TagSize returns the tag size in bytes of the underlying AEAD crypter.
 func (hc *S2AHalfConnection) TagSize() int {
 	return hc.aeadCrypter.tagSize()
 }

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -100,6 +100,11 @@ func (hc *S2AHalfConnection) UpdateKey() error {
 	return nil
 }
 
+// TagSize returns the tag size of the underlying AEAD crypter.
+func (hc *S2AHalfConnection) TagSize() int {
+	return hc.aeadCrypter.tagSize()
+}
+
 // updateCrypterAndNonce takes a new traffic secret and updates the crypter
 // and nonce. Note that the mutex must be held while calling this function.
 func (hc *S2AHalfConnection) updateCrypterAndNonce(newTrafficSecret []byte) error {

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -374,7 +374,7 @@ func TestS2AHalfConnectionTagSize(t *testing.T) {
 			}
 			trafficSecret := make([]byte, cs.trafficSecretSize())
 			key := make([]byte, cs.keySize())
-			hc, err := NewHalfConn(ciphersuite, trafficSecret)
+			hc, err := NewHalfConn(ciphersuite, trafficSecret, 0 /* sequence */)
 			if err != nil {
 				t.Fatalf("NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
 			}

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -360,3 +360,20 @@ func TestS2AHalfConnectionUpdateKey(t *testing.T) {
 		})
 	}
 }
+
+func TestS2AHalfConnectionTagSize(t *testing.T) {
+	ciphersuite := s2apb.Ciphersuite_AES_256_GCM_SHA384
+	trafficSecret := make([]byte, 48)
+	key := make([]byte, 32)
+	hc, err := NewHalfConn(ciphersuite, trafficSecret)
+	if err != nil {
+		t.Fatalf("NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
+	}
+	crypter, err := newAESGCM(key)
+	if err != nil {
+		t.Fatalf("newAESGCM(%v) failed: %v", key, err)
+	}
+	if got, want := hc.TagSize(), crypter.tagSize(); got != want {
+		t.Errorf("hc.TagSize() = %v, want %v", got, want)
+	}
+}

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -362,18 +362,30 @@ func TestS2AHalfConnectionUpdateKey(t *testing.T) {
 }
 
 func TestS2AHalfConnectionTagSize(t *testing.T) {
-	ciphersuite := s2apb.Ciphersuite_AES_256_GCM_SHA384
-	trafficSecret := make([]byte, 48)
-	key := make([]byte, 32)
-	hc, err := NewHalfConn(ciphersuite, trafficSecret)
-	if err != nil {
-		t.Fatalf("NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
-	}
-	crypter, err := newAESGCM(key)
-	if err != nil {
-		t.Fatalf("newAESGCM(%v) failed: %v", key, err)
-	}
-	if got, want := hc.TagSize(), crypter.tagSize(); got != want {
-		t.Errorf("hc.TagSize() = %v, want %v", got, want)
+	for _, ciphersuite := range []s2apb.Ciphersuite{
+		s2apb.Ciphersuite_AES_128_GCM_SHA256,
+		s2apb.Ciphersuite_AES_256_GCM_SHA384,
+		s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+	} {
+		t.Run(ciphersuite.String(), func(t *testing.T) {
+			cs, err := newCiphersuite(ciphersuite)
+			if err != nil {
+				t.Fatalf("newCiphersuite(%v) failed: %v", ciphersuite, err)
+			}
+			trafficSecret := make([]byte, cs.trafficSecretSize())
+			key := make([]byte, cs.keySize())
+			hc, err := NewHalfConn(ciphersuite, trafficSecret)
+			if err != nil {
+				t.Fatalf("NewHalfConn(%v, %v) failed: %v", ciphersuite, trafficSecret, err)
+			}
+			crypter, err := newAESGCM(key)
+			if err != nil {
+				t.Fatalf("newAESGCM(%v) failed: %v", key, err)
+			}
+			if got, want := hc.TagSize(), crypter.tagSize(); got != want {
+				t.Errorf("hc.TagSize() = %v, want %v", got, want)
+			}
+		})
+
 	}
 }

--- a/security/s2a/internal/crypter/record.go
+++ b/security/s2a/internal/crypter/record.go
@@ -80,9 +80,8 @@ func NewConn(o *ConnOptions) (net.Conn, error) {
 		return nil, fmt.Errorf("failed to create outbound half connection: %v", err)
 	}
 
-	// TODO(rnkim): Add TagSize() to Half Connection.
 	// The tag size for the in/out connections should be the same.
-	overheadSize := tlsRecordHeaderSize + tlsRecordTypeSize + inConn.aeadCrypter.tagSize()
+	overheadSize := tlsRecordHeaderSize + tlsRecordTypeSize + inConn.TagSize()
 	var unusedBuf []byte
 	// TODO(gud): Potentially optimize unusedBuf with pre-allocation.
 	if o.unusedBuf != nil {


### PR DESCRIPTION
Added the `TagSize` API to the half connection. This will allow the record protocol file to access the AEAD crypter's tag size from the half connection. This is needed once we move the AEAD crypter to its own package and the half connection to its own package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/39)
<!-- Reviewable:end -->
