### PR TITLE
Rename s2aAeadCrypter to s2aAEADCrypter

### DIFF
--- a/security/s2a/internal/crypter/aeadcrypter.go
+++ b/security/s2a/internal/crypter/aeadcrypter.go
@@ -1,8 +1,8 @@
 package crypter
 
-// s2aAeadCrypter is the interface for an AEAD cipher used by the S2A record
+// s2aAEADCrypter is the interface for an AEAD cipher used by the S2A record
 // protocol.
-type s2aAeadCrypter interface {
+type s2aAEADCrypter interface {
 	// encrypt encrypts the plaintext and computes the tag of dst and plaintext.
 	// dst and plaintext may fully overlap or not at all.
 	encrypt(dst, plaintext, nonce, aad []byte) ([]byte, error)

--- a/security/s2a/internal/crypter/aesgcm.go
+++ b/security/s2a/internal/crypter/aesgcm.go
@@ -37,7 +37,7 @@ type aesgcm struct {
 
 // newAESGCM creates an AES-GCM crypter instance. Note that the key must be
 // either 128 bits or 256 bits.
-func newAESGCM(key []byte) (s2aAeadCrypter, error) {
+func newAESGCM(key []byte) (s2aAEADCrypter, error) {
 	if len(key) != aes128GcmKeySize && len(key) != aes256GcmKeySize {
 		return nil, fmt.Errorf("%d or %d bytes, given: %d", aes128GcmKeySize, aes256GcmKeySize, len(key))
 	}

--- a/security/s2a/internal/crypter/aesgcm_test.go
+++ b/security/s2a/internal/crypter/aesgcm_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // getGCMCryptoPair outputs a sender/receiver pair on AES-GCM.
-func getGCMCryptoPair(key []byte, t *testing.T) (s2aAeadCrypter, s2aAeadCrypter) {
+func getGCMCryptoPair(key []byte, t *testing.T) (s2aAEADCrypter, s2aAEADCrypter) {
 	sender, err := newAESGCM(key)
 	if err != nil {
 		t.Fatalf("newAESGCM(ClientSide, key) = %v", err)
@@ -47,7 +47,7 @@ func wycheProofTestVectorFilter(testGroup testutil.TestGroup) bool {
 		testGroup.TagSize != 128
 }
 
-func testGCMEncryptionDecryption(sender s2aAeadCrypter, receiver s2aAeadCrypter, tc *testutil.CryptoTestVector, t *testing.T) {
+func testGCMEncryptionDecryption(sender s2aAEADCrypter, receiver s2aAEADCrypter, tc *testutil.CryptoTestVector, t *testing.T) {
 	// ciphertext is: encrypted text + tag.
 	ciphertext := append(tc.Ciphertext, tc.Tag...)
 
@@ -70,7 +70,7 @@ func testGCMEncryptionDecryption(sender s2aAeadCrypter, receiver s2aAeadCrypter,
 	}
 }
 
-func testGCMEncryptRoundtrip(sender s2aAeadCrypter, receiver s2aAeadCrypter, t *testing.T) {
+func testGCMEncryptRoundtrip(sender s2aAEADCrypter, receiver s2aAEADCrypter, t *testing.T) {
 	// Construct a dummy nonce.
 	nonce := make([]byte, nonceSize)
 

--- a/security/s2a/internal/crypter/chachapoly.go
+++ b/security/s2a/internal/crypter/chachapoly.go
@@ -37,7 +37,7 @@ type chachapoly struct {
 
 // newChachaPoly creates a Chacha-Poly crypter instance. Note that the key must be
 // chacha20Poly1305KeySize bytes in length.
-func newChachaPoly(key []byte) (s2aAeadCrypter, error) {
+func newChachaPoly(key []byte) (s2aAEADCrypter, error) {
 	if len(key) != chacha20Poly1305KeySize {
 		return nil, fmt.Errorf("%d bytes, given: %d", chacha20Poly1305KeySize, len(key))
 	}

--- a/security/s2a/internal/crypter/chachapoly_test.go
+++ b/security/s2a/internal/crypter/chachapoly_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // getChachaPolyCrypterPair outputs a sender/receiver pair of CHACHA-POLY AEAD crypters.
-func getChachaPolyCrypterPair(key []byte, t *testing.T) (s2aAeadCrypter, s2aAeadCrypter) {
+func getChachaPolyCrypterPair(key []byte, t *testing.T) (s2aAEADCrypter, s2aAEADCrypter) {
 	sender, err := newChachaPoly(key)
 	if err != nil {
 		t.Fatalf("newChachaPoly(ClientSide, key) = %v", err)
@@ -47,7 +47,7 @@ func wycheProofTestVectorFilterChachaPoly(testGroup testutil.TestGroup) bool {
 		testGroup.TagSize != 128
 }
 
-func testChachaPolyEncryptionDecryption(sender s2aAeadCrypter, receiver s2aAeadCrypter, tc *testutil.CryptoTestVector, t *testing.T) {
+func testChachaPolyEncryptionDecryption(sender s2aAEADCrypter, receiver s2aAEADCrypter, tc *testutil.CryptoTestVector, t *testing.T) {
 	// Ciphertext is: encrypted text + tag.
 	ciphertext := append(tc.Ciphertext, tc.Tag...)
 
@@ -70,7 +70,7 @@ func testChachaPolyEncryptionDecryption(sender s2aAeadCrypter, receiver s2aAeadC
 	}
 }
 
-func testChachaPolyEncryptRoundtrip(sender s2aAeadCrypter, receiver s2aAeadCrypter, t *testing.T) {
+func testChachaPolyEncryptRoundtrip(sender s2aAEADCrypter, receiver s2aAEADCrypter, t *testing.T) {
 	// Construct a dummy nonce.
 	nonce := make([]byte, nonceSize)
 

--- a/security/s2a/internal/crypter/ciphersuite.go
+++ b/security/s2a/internal/crypter/ciphersuite.go
@@ -25,7 +25,7 @@ type ciphersuite interface {
 	hashFunction() func() hash.Hash
 	// aeadCrypter takes a key and creates an AEAD crypter for the ciphersuite
 	// using that key.
-	aeadCrypter(key []byte) (s2aAeadCrypter, error)
+	aeadCrypter(key []byte) (s2aAEADCrypter, error)
 }
 
 func newCiphersuite(ciphersuite s2a_proto.Ciphersuite) (ciphersuite, error) {
@@ -49,7 +49,7 @@ func (aesgcm128sha256) keySize() int                                   { return 
 func (aesgcm128sha256) nonceSize() int                                 { return nonceSize }
 func (aesgcm128sha256) trafficSecretSize() int                         { return sha256DigestSize }
 func (aesgcm128sha256) hashFunction() func() hash.Hash                 { return sha256.New }
-func (aesgcm128sha256) aeadCrypter(key []byte) (s2aAeadCrypter, error) { return newAESGCM(key) }
+func (aesgcm128sha256) aeadCrypter(key []byte) (s2aAEADCrypter, error) { return newAESGCM(key) }
 
 // aesgcm256sha384 is the AES-256-GCM-SHA384 implementation of the ciphersuite
 // interface.
@@ -59,7 +59,7 @@ func (aesgcm256sha384) keySize() int                                   { return 
 func (aesgcm256sha384) nonceSize() int                                 { return nonceSize }
 func (aesgcm256sha384) trafficSecretSize() int                         { return sha384DigestSize }
 func (aesgcm256sha384) hashFunction() func() hash.Hash                 { return sha512.New384 }
-func (aesgcm256sha384) aeadCrypter(key []byte) (s2aAeadCrypter, error) { return newAESGCM(key) }
+func (aesgcm256sha384) aeadCrypter(key []byte) (s2aAEADCrypter, error) { return newAESGCM(key) }
 
 // chachapolysha256 is the ChaChaPoly-SHA256 implementation of the ciphersuite
 // interface.
@@ -69,4 +69,4 @@ func (chachapolysha256) keySize() int                                   { return
 func (chachapolysha256) nonceSize() int                                 { return nonceSize }
 func (chachapolysha256) trafficSecretSize() int                         { return sha256DigestSize }
 func (chachapolysha256) hashFunction() func() hash.Hash                 { return sha256.New }
-func (chachapolysha256) aeadCrypter(key []byte) (s2aAeadCrypter, error) { return newChachaPoly(key) }
+func (chachapolysha256) aeadCrypter(key []byte) (s2aAEADCrypter, error) { return newChachaPoly(key) }

--- a/security/s2a/internal/crypter/ciphersuite_test.go
+++ b/security/s2a/internal/crypter/ciphersuite_test.go
@@ -17,7 +17,7 @@ func TestCiphersuites(t *testing.T) {
 		key                                   []byte
 		keySize, nonceSize, trafficSecretSize int
 		hashFunction                          func() hash.Hash
-		aeadCrypter                           s2aAeadCrypter
+		aeadCrypter                           s2aAEADCrypter
 	}{
 		{
 			s2aProtoCiphersuite: s2a_proto.Ciphersuite_AES_128_GCM_SHA256,

--- a/security/s2a/internal/crypter/halfconn.go
+++ b/security/s2a/internal/crypter/halfconn.go
@@ -24,7 +24,7 @@ type S2AHalfConnection struct {
 	expander hkdfExpander
 	// mutex guards sequence, aeadCrypter, trafficSecret, and nonce.
 	mutex         sync.Mutex
-	aeadCrypter   s2aAeadCrypter
+	aeadCrypter   s2aAEADCrypter
 	sequence      counter
 	trafficSecret []byte
 	nonce         []byte

--- a/security/s2a/internal/crypter/halfconn_test.go
+++ b/security/s2a/internal/crypter/halfconn_test.go
@@ -21,9 +21,9 @@ func getHalfConnPair(ciphersuite s2apb.Ciphersuite, trafficSecret []byte, t *tes
 	return sender, receiver
 }
 
-// aeadCrypterEqual checks whether the given s2aAeadCrypters encrypt a simple
+// aeadCrypterEqual checks whether the given s2aAEADCrypters encrypt a simple
 // string identically.
-func aeadCrypterEqual(a s2aAeadCrypter, b s2aAeadCrypter, t *testing.T) bool {
+func aeadCrypterEqual(a s2aAEADCrypter, b s2aAEADCrypter, t *testing.T) bool {
 	nonce := make([]byte, nonceSize)
 	const plaintext = "This is plaintext"
 	ciphertextA, err := a.encrypt(nil, []byte(plaintext), nonce, nil)

--- a/security/s2a/internal/crypter/testutil/common.go
+++ b/security/s2a/internal/crypter/testutil/common.go
@@ -10,7 +10,7 @@ const (
 	InvalidResult = "invalid"
 )
 
-// CryptoTestVector is a struct representing a test vector for an s2aAeadCrypter
+// CryptoTestVector is a struct representing a test vector for an s2aAEADCrypter
 // instance.
 type CryptoTestVector struct {
 	Desc                                        string


### PR DESCRIPTION
Looking at https://github.com/golang/go/wiki/CodeReviewComments#initialisms, I think the interface should be called `s2aAEADCrypter` rather than `s2aAeadCrypter` since AEAD is an acronym for *authenticated encryption with associated data*.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/40)
<!-- Reviewable:end -->
