### PR TITLE
Fix Handshaker Service Address naming

### DIFF
--- a/security/s2a/internal/handshaker/handshaker.go
+++ b/security/s2a/internal/handshaker/handshaker.go
@@ -234,7 +234,7 @@ func (h *s2aHandshaker) setUpSession(req *s2apb.SessionReq) (net.Conn, *s2apb.Se
 		UnusedBuf:        extra,
 		InSequence:       result.GetState().GetInSequence(),
 		OutSequence:      result.GetState().GetOutSequence(),
-		HsAddr:           h.hsAddr,
+		HSAddr:           h.hsAddr,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/security/s2a/internal/record/record.go
+++ b/security/s2a/internal/record/record.go
@@ -54,7 +54,7 @@ type conn struct {
 	hsAddr string
 }
 
-// ConnParameters holds the parameters used for creating a new conn object. 
+// ConnParameters holds the parameters used for creating a new conn object.
 type ConnParameters struct {
 	// NetConn is the TCP connection to the peer. This parameter is required.
 	NetConn net.Conn
@@ -67,23 +67,23 @@ type ConnParameters struct {
 	// InTrafficSecret is the traffic secret used to derive the session key for
 	// the inbound direction. This parameter is required.
 	InTrafficSecret []byte
-	// OutTrafficSecret is the traffic secret used to derive the session key 
+	// OutTrafficSecret is the traffic secret used to derive the session key
 	// for the outbound direction. This parameter is required.
 	OutTrafficSecret []byte
 	// UnusedBuf is the data read from the network that has not yet been
-	// decrypted. This parameter is optional. If not provided, then no 
+	// decrypted. This parameter is optional. If not provided, then no
 	// application data was sent in the same flight of messages as the final
 	// handshake message.
 	UnusedBuf []byte
-	// InSequence is the sequence number of the next, incoming, TLS record. 
+	// InSequence is the sequence number of the next, incoming, TLS record.
 	// This parameter is required.
 	InSequence uint64
-	// OutSequence is the sequence number of the next, outgoing, TLS record. 
+	// OutSequence is the sequence number of the next, outgoing, TLS record.
 	// This parameter is required.
 	OutSequence uint64
-	// hsAddr stores the address of the S2A handshaker service. This parameter 
+	// HSAddr stores the address of the S2A handshaker service. This parameter
 	// is optional. If not provided, then TLS resumption is disabled.
-	HsAddr string
+	HSAddr string
 }
 
 func NewConn(o *ConnParameters) (net.Conn, error) {
@@ -120,7 +120,7 @@ func NewConn(o *ConnParameters) (net.Conn, error) {
 		outRecordsBuf: make([]byte, outBufSize),
 		nextRecord:    unusedBuf,
 		overheadSize:  overheadSize,
-		hsAddr:        o.HsAddr,
+		hsAddr:        o.HSAddr,
 	}
 	return s2aConn, nil
 }

--- a/security/s2a/internal/record/record_test.go
+++ b/security/s2a/internal/record/record_test.go
@@ -41,7 +41,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				TLSVersion:       s2apb.TLSVersion_TLS1_3,
 				InTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				OutTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				HsAddr:           "test handshaker address",
+				HSAddr:           "test handshaker address",
 			},
 			outErr: true,
 		},
@@ -53,7 +53,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				TLSVersion:       s2apb.TLSVersion_TLS1_3,
 				InTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				OutTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				HsAddr:           "test handshaker address",
+				HSAddr:           "test handshaker address",
 			},
 			outErr: true,
 		},
@@ -65,7 +65,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				TLSVersion:       s2apb.TLSVersion_TLS1_2,
 				InTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				OutTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				HsAddr:           "test handshaker address",
+				HSAddr:           "test handshaker address",
 			},
 			outErr: true,
 		},
@@ -77,7 +77,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				TLSVersion:       s2apb.TLSVersion_TLS1_3,
 				InTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				OutTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				HsAddr:           "test handshaker address",
+				HSAddr:           "test handshaker address",
 			},
 			// outOverheadSize = header size (5) + record type byte (1) +
 			// tag size (16).
@@ -92,7 +92,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				TLSVersion:       s2apb.TLSVersion_TLS1_3,
 				InTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				OutTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				HsAddr:           "test handshaker address",
+				HSAddr:           "test handshaker address",
 			},
 			// outOverheadSize = header size (5) + record type byte (1) +
 			// tag size (16).
@@ -107,7 +107,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				TLSVersion:       s2apb.TLSVersion_TLS1_3,
 				InTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				OutTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-				HsAddr:           "test handshaker address",
+				HSAddr:           "test handshaker address",
 			},
 			// outOverheadSize = header size (5) + record type byte (1) +
 			// tag size (16).
@@ -123,7 +123,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				InTrafficSecret:  testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				OutTrafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
 				UnusedBuf:        testutil.Dehex("ffffffff"),
-				HsAddr:           "test handshaker address",
+				HSAddr:           "test handshaker address",
 			},
 			outUnusedBytesBuf: testutil.Dehex("ffffffff"),
 			// outOverheadSize = header size (5) + record type byte (1) +
@@ -148,7 +148,7 @@ func TestNewS2ARecordConn(t *testing.T) {
 				t.Errorf("conn.overheadSize = %v, want %v", got, want)
 			}
 			if got, want := conn.hsAddr, tc.outHandshakerServiceAddr; got != want {
-				t.Errorf("conn.HsAddr = %v, want %v", got, want)
+				t.Errorf("conn.HSAddr = %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixed the Handshaker service capitalization formatting. I believe the "S" should be capitalized (https://github.com/golang/go/wiki/CodeReviewComments#initialisms). The spacing was automatically changed by my linter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/46)
<!-- Reviewable:end -->
