### PR TITLE
Add S2A E2E test using fake handshaker service

### DIFF
--- a/security/s2a/internal/fakehandshaker/main.go
+++ b/security/s2a/internal/fakehandshaker/main.go
@@ -25,6 +25,7 @@ import (
 	"net"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/security/s2a/internal/fakehandshaker/service"
 	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
 )
 
@@ -40,7 +41,7 @@ func main() {
 		log.Fatalf("failed to listen on port %s: %v", *port, err)
 	}
 	s := grpc.NewServer()
-	s2apb.RegisterS2AServiceServer(s, &fakeHandshakerService{})
+	s2apb.RegisterS2AServiceServer(s, &service.FakeHandshakerService{})
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}

--- a/security/s2a/internal/fakehandshaker/service/s2a_service.go
+++ b/security/s2a/internal/fakehandshaker/service/s2a_service.go
@@ -16,7 +16,7 @@
  *
  */
 
-package main
+package service
 
 import (
 	"bytes"
@@ -52,12 +52,12 @@ const (
 
 const (
 	inKey  = "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk"
-	outKey = "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj"
+	outKey = "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk"
 )
 
-// fakeHandshakerService implements the s2apb.S2AServiceServer. The fake
+// FakeHandshakerService implements the s2apb.S2AServiceServer. The fake
 // handshaker service should not be used by more than 1 application at a time.
-type fakeHandshakerService struct {
+type FakeHandshakerService struct {
 	assistingClient bool
 	state           handshakeState
 	peerIdentity    *s2apb.Identity
@@ -65,7 +65,7 @@ type fakeHandshakerService struct {
 }
 
 // SetUpSession sets up the S2A session.
-func (hs *fakeHandshakerService) SetUpSession(stream s2apb.S2AService_SetUpSessionServer) error {
+func (hs *FakeHandshakerService) SetUpSession(stream s2apb.S2AService_SetUpSessionServer) error {
 	for {
 		sessionReq, err := stream.Recv()
 		if err != nil {
@@ -95,7 +95,7 @@ func (hs *fakeHandshakerService) SetUpSession(stream s2apb.S2AService_SetUpSessi
 }
 
 // processClientStart processes a ClientSessionStartReq.
-func (hs *fakeHandshakerService) processClientStart(req *s2apb.SessionReq_ClientStart) *s2apb.SessionResp {
+func (hs *FakeHandshakerService) processClientStart(req *s2apb.SessionReq_ClientStart) *s2apb.SessionResp {
 	resp := s2apb.SessionResp{}
 	if hs.state != initial {
 		resp.Status = &s2apb.SessionStatus{
@@ -132,7 +132,7 @@ func (hs *fakeHandshakerService) processClientStart(req *s2apb.SessionReq_Client
 }
 
 // processServerStart processes a ServerSessionStartReq.
-func (hs *fakeHandshakerService) processServerStart(req *s2apb.SessionReq_ServerStart) *s2apb.SessionResp {
+func (hs *FakeHandshakerService) processServerStart(req *s2apb.SessionReq_ServerStart) *s2apb.SessionResp {
 	resp := s2apb.SessionResp{}
 	if hs.state != initial {
 		resp.Status = &s2apb.SessionStatus{
@@ -181,7 +181,7 @@ func (hs *fakeHandshakerService) processServerStart(req *s2apb.SessionReq_Server
 }
 
 // processNext processes a SessionNext request.
-func (hs *fakeHandshakerService) processNext(req *s2apb.SessionReq_Next) *s2apb.SessionResp {
+func (hs *FakeHandshakerService) processNext(req *s2apb.SessionReq_Next) *s2apb.SessionResp {
 	resp := s2apb.SessionResp{}
 	if hs.assistingClient {
 		if hs.state != sent {
@@ -239,7 +239,7 @@ func (hs *fakeHandshakerService) processNext(req *s2apb.SessionReq_Next) *s2apb.
 }
 
 // getSessionResult returns a dummy SessionResult.
-func (hs *fakeHandshakerService) getSessionResult() *s2apb.SessionResult {
+func (hs *FakeHandshakerService) getSessionResult() *s2apb.SessionResult {
 	res := s2apb.SessionResult{}
 	res.ApplicationProtocol = grpcAppProtocol
 	res.State = &s2apb.SessionState{

--- a/security/s2a/internal/fakehandshaker/service/s2a_service_test.go
+++ b/security/s2a/internal/fakehandshaker/service/s2a_service_test.go
@@ -16,7 +16,7 @@
  *
  */
 
-package main
+package service
 
 import (
 	"errors"
@@ -287,7 +287,7 @@ func TestSetupSession(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			hs := fakeHandshakerService{}
+			hs := FakeHandshakerService{}
 			stream := &fakeS2ASetupSessionServer{reqs: tc.reqs}
 			if got, want := hs.SetUpSession(stream) == nil, !tc.hasNonOKStatus; got != want {
 				t.Errorf("hs.SetUpSession(%v) = (err=nil) = %v, want %v", stream, got, want)

--- a/security/s2a/s2a_e2e_test.go
+++ b/security/s2a/s2a_e2e_test.go
@@ -1,0 +1,145 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package s2a
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	pb "google.golang.org/grpc/examples/helloworld/helloworld"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/security/s2a/internal/fakehandshaker/service"
+	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
+)
+
+const (
+	clientHostname = "test_client_hostname"
+	serverSpiffeId = "test_server_spiffe_id"
+	clientMessage  = "echo"
+)
+
+// server is used to implement helloworld.GreeterServer.
+type server struct {
+	pb.UnimplementedGreeterServer
+}
+
+// SayHello implements helloworld.GreeterServer.
+func (s *server) SayHello(_ context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+	return &pb.HelloReply{Message: "Hello " + in.GetName()}, nil
+}
+
+// startFakeHandshakerServer starts up a fake handshaker server and returns the
+// address that it is listening on.
+func startFakeHandshakerServer(t *testing.T) string {
+	lis, err := net.Listen("tcp", ":")
+	if err != nil {
+		t.Fatalf("net.Listen(tcp, :0) failed: %v", err)
+	}
+	s := grpc.NewServer()
+	s2apb.RegisterS2AServiceServer(s, &service.FakeHandshakerService{})
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Fatalf("s.Serve(%v) failed: %v", lis, err)
+		}
+	}()
+	return lis.Addr().String()
+}
+
+// startServer starts up a server and returns the address that it is listening
+// on.
+func startServer(t *testing.T, serverHandshakerAddr string) string {
+	serverOpts := &ServerOptions{
+		LocalIdentities:          []Identity{NewSpiffeID(serverSpiffeId)},
+		HandshakerServiceAddress: serverHandshakerAddr,
+	}
+	creds, err := NewServerCreds(serverOpts)
+	if err != nil {
+		t.Fatalf("NewServerCreds(%v) failed: %v", serverOpts, err)
+	}
+
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen(tcp, :0) failed: %v", err)
+	}
+	s := grpc.NewServer(grpc.Creds(creds))
+	pb.RegisterGreeterServer(s, &server{})
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			t.Fatalf("s.Serve(%v) failed: %v", lis, err)
+		}
+	}()
+	return lis.Addr().String()
+}
+
+// runClient starts up a client and calls the server.
+func runClient(t *testing.T, ctx context.Context, clientHandshakerAddr, serverAddr string) {
+	clientOpts := &ClientOptions{
+		TargetIdentities:         []Identity{NewSpiffeID(serverSpiffeId)},
+		LocalIdentity:            NewHostname(clientHostname),
+		HandshakerServiceAddress: clientHandshakerAddr,
+	}
+	creds, err := NewClientCreds(clientOpts)
+	if err != nil {
+		t.Fatalf("NewClientCreds(%v) failed: %v", clientOpts, err)
+	}
+	dialOptions := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithBlock(),
+	}
+
+	grpclog.Info("client dialing server at address: %v", serverAddr)
+	// Establish a connection to the server.
+	conn, err := grpc.Dial(serverAddr, dialOptions...)
+	if err != nil {
+		t.Fatalf("grpc.Dial(%v, %v) failed: %v", serverAddr, dialOptions, err)
+	}
+	defer conn.Close()
+
+	// Contact the server.
+	c := pb.NewGreeterClient(conn)
+	req := &pb.HelloRequest{Name: clientMessage}
+	grpclog.Infof("client calling SayHello with request: %v", req)
+	resp, err := c.SayHello(ctx, req, grpc.WaitForReady(true))
+	if err != nil {
+		t.Fatalf("c.SayHello(%v, %v) failed: %v", ctx, req, err)
+	}
+	if got, want := resp.GetMessage(), "Hello "+clientMessage; got != want {
+		t.Errorf("r.GetMessage() = %v, want %v", got, want)
+	}
+}
+
+func TestE2EClientServerUsingFakeHS(t *testing.T) {
+	// Start the handshaker servers for the client and server.
+	serverHandshakerAddr := startFakeHandshakerServer(t)
+	grpclog.Infof("fake handshaker for server running at address: %v", serverHandshakerAddr)
+	clientHandshakerAddr := startFakeHandshakerServer(t)
+	grpclog.Infof("fake handshaker for client running at address: %v", clientHandshakerAddr)
+
+	// Start the server.
+	serverAddr := startServer(t, serverHandshakerAddr)
+	grpclog.Infof("server running at address: %v", serverAddr)
+
+	// Finally, start up the client.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	runClient(t, ctx, clientHandshakerAddr, serverAddr)
+}


### PR DESCRIPTION
Added e2e testing using the fake handshaker service. Since `Read` and `Write` are currently unimplemented, I temporarily replaced the implementation with:
```
func (p *conn) Read(b []byte) (n int, err error) {
	return p.Conn.Read(b)
}

func (p *conn) Write(b []byte) (n int, err error) {
	return p.Conn.Write(b)
}
```
The e2e test starts up 2 fake handshaker services (1 for the client and 1 for the server) and then the server. These are run using separate Go routines.

Finally, the client is started up and blocks until a connection is made with the server, and verifies that it received the correct message from the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/51)
<!-- Reviewable:end -->
