### PR TITLE
Fix S2A E2E greeter client

### DIFF
--- a/security/s2a/examples/e2e_client/main.go
+++ b/security/s2a/examples/e2e_client/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	// Set up the client-side S2A transport credentials.
 	clientOpts := &s2a.ClientOptions{
+		LocalIdentity:            s2a.NewHostname("local_identity"),
 		HandshakerServiceAddress: *s2aServerAddr,
 	}
 	creds, err := s2a.NewClientCreds(clientOpts)
@@ -63,7 +64,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not greet: %v", err)
 	}
-	if r.String() != "Hello, S2A team!" {
+	if r.GetMessage() != "Hello, S2A team!" {
 		os.Exit(1)
 	}
 	log.Printf("Greeting: %s", r.GetMessage())


### PR DESCRIPTION
Fixed the S2A E2E greeter client by adding a local identity as well as fixing the response message string comparison.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/60)
<!-- Reviewable:end -->
