### PR TITLE
Fix clearing new session ticket message

### DIFF
--- a/security/s2a/internal/record/record.go
+++ b/security/s2a/internal/record/record.go
@@ -286,7 +286,7 @@ func (p *conn) Read(b []byte) (n int, err error) {
 				}
 			}
 			// Clear the body of the alert message.
-			p.pendingApplicationData = p.pendingApplicationData[tlsAlertSize:]
+			p.pendingApplicationData = p.pendingApplicationData[:0]
 			// TODO: add support for more alert types.
 			return 0, nil
 		case handshake:
@@ -306,11 +306,12 @@ func (p *conn) Read(b []byte) (n int, err error) {
 					return 0, err
 				}
 				// Clear the body of the key update message.
-				p.pendingApplicationData = p.pendingApplicationData[tlsHandshakeMsgTypeSize+tlsHandshakeLengthSize+tlsHandshakeKeyUpdateMsgSize:]
+				p.pendingApplicationData = p.pendingApplicationData[:0]
 				return 0, nil
 			} else if handshakeMsgType == tlsHandshakeNewSessionTicket {
 				// TODO: implement this later.
 				grpclog.Infof("Session ticket was received")
+				p.pendingApplicationData = p.pendingApplicationData[:0]
 				return 0, nil
 			}
 			return 0, errors.New("unknown handshake message type")

--- a/security/s2a/internal/record/record_test.go
+++ b/security/s2a/internal/record/record_test.go
@@ -940,15 +940,24 @@ func TestConnReadAlert(t *testing.T) {
 				t.Fatalf("NewConn() failed: %v", err)
 			}
 			plaintext := make([]byte, tlsRecordMaxPlaintextSize)
-			_, err = c.Read(plaintext)
+			n, err := c.Read(plaintext)
 			if got, want := err == nil, !tc.outErr; got != want {
 				t.Errorf("c.Read(plaintext) = (err=nil) = %v, want %v", got, want)
 			}
 			if err != nil {
 				return
 			}
+			if got, want := n, 0; got != want {
+				t.Errorf("c.Read(plaintext) = %v, want %v", got, want)
+			}
+			if got, want := plaintext, make([]byte, tlsRecordMaxPlaintextSize); !bytes.Equal(got, want) {
+				t.Errorf("c.Read(plaintext) modified plaintext")
+			}
 			if got, want := f.closed, tc.outClosed; got != want {
 				t.Errorf("f.closed = %v, want %v", got, want)
+			}
+			if got, want := len(c.(*conn).pendingApplicationData), 0; got != want {
+				t.Errorf("len(c.(*conn).pendingApplicationData) = %v, want %v", got, want)
 			}
 		})
 	}
@@ -1023,6 +1032,64 @@ func TestConnReadKeyUpdate(t *testing.T) {
 				if got, want := plaintext, outPlaintext; !bytes.Equal(got, want) {
 					t.Errorf("c.Read(plaintext) = %v, want %v", got, want)
 				}
+			}
+			if got, want := len(c.(*conn).pendingApplicationData), 0; got != want {
+				t.Errorf("len(c.(*conn).pendingApplicationData) = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestConnNewSessionTicket(t *testing.T) {
+	for _, tc := range []struct {
+		desc            string
+		ciphersuite     s2apb.Ciphersuite
+		trafficSecret   []byte
+		completedRecord []byte
+	}{
+		{
+			desc:            "AES-128-GCM-SHA256 new session ticket",
+			ciphersuite:     s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret:   testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecord: testutil.Dehex("1703030016c7d6d72499478b3d80281cae5b7c1a3e5cd553aae716"),
+		},
+		{
+			desc:            "AES-256-GCM-SHA384 new session ticket",
+			ciphersuite:     s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret:   testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecord: testutil.Dehex("170303001611dddd6fc4869be0e1c12a5a29db1aa2e5814e5894e5"),
+		},
+		{
+			desc:            "CHACHA20-POLY1305-SHA256 new session ticket",
+			ciphersuite:     s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret:   testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecord: testutil.Dehex("1703030016fc75cc914510008c6B45bb46b1f030921006c3556882"),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			c, err := NewConn(&ConnParameters{
+				NetConn:          &fakeConn{in: [][]byte{tc.completedRecord}},
+				Ciphersuite:      tc.ciphersuite,
+				TLSVersion:       s2apb.TLSVersion_TLS1_3,
+				InTrafficSecret:  tc.trafficSecret,
+				OutTrafficSecret: tc.trafficSecret,
+			})
+			if err != nil {
+				t.Fatalf("NewConn() failed: %v", err)
+			}
+			plaintext := make([]byte, tlsRecordMaxPlaintextSize)
+			n, err := c.Read(plaintext)
+			if err != nil {
+				t.Fatalf("c.Read(plaintext) failed: %v", err)
+			}
+			if got, want := n, 0; got != want {
+				t.Errorf("c.Read(plaintext) = %v, want %v", got, want)
+			}
+			if got, want := plaintext, make([]byte, tlsRecordMaxPlaintextSize); !bytes.Equal(got, want) {
+				t.Errorf("c.Read(plaintext) modified plaintext")
+			}
+			if got, want := len(c.(*conn).pendingApplicationData), 0; got != want {
+				t.Errorf("len(c.(*conn).pendingApplicationData) = %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixed the issue of not clearing the body of the message when receiving a new session ticket. This caused issues when communication with a Go/C++ greeter server. 

Also, I changed the code to clear the entire `p.pendingApplicationData`. Before, we didn't clear the entire buffer in case there were trailing bytes that we were still interested in. However, for handshake messages and alerts, I don't think there will ever be trailing bytes at the end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/62)
<!-- Reviewable:end -->
