### PR TITLE
Add resumption handling to the S2A client

### DIFF
--- a/security/s2a/internal/record/record.go
+++ b/security/s2a/internal/record/record.go
@@ -28,7 +28,6 @@ import (
 	"net"
 	"sync"
 
-	"google.golang.org/grpc/grpclog"
 	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
 	"google.golang.org/grpc/security/s2a/internal/record/internal/halfconn"
 )
@@ -58,6 +57,17 @@ type alertDescription byte
 
 const (
 	closeNotify alertDescription = 0
+)
+
+// sessionTicketState is used to determine whether session tickets have not yet
+// been received, are in the process of being received, or have finished
+// receiving.
+type sessionTicketState byte
+
+const (
+	ticketsNotYetReceived sessionTicketState = 0
+	receivingTickets      sessionTicketState = 1
+	notReceivingTickets   sessionTicketState = 2
 )
 
 const (
@@ -103,12 +113,12 @@ const (
 const (
 	// These are TLS 1.3 handshake-specific constants.
 
-	// tlsHandshakeNewSessionTicket is the prefix of a handshake new session
+	// tlsHandshakeNewSessionTicketType is the prefix of a handshake new session
 	// ticket message of TLS 1.3.
-	tlsHandshakeNewSessionTicket = 4
-	// tlsHandshakeKeyUpdatePrefix is the prefix of a handshake key update
-	// message of TLS 1.3.
-	tlsHandshakeKeyUpdatePrefix = 24
+	tlsHandshakeNewSessionTicketType = 4
+	// tlsHandshakeKeyUpdateType is the prefix of a handshake key update message
+	// of TLS 1.3.
+	tlsHandshakeKeyUpdateType = 24
 	// tlsHandshakeMsgTypeSize is the size in bytes of the TLS 1.3 handshake
 	// message type field.
 	tlsHandshakeMsgTypeSize = 1
@@ -121,6 +131,11 @@ const (
 	// tlsHandshakePrefixSize is the size in bytes of the prefix of the TLS 1.3
 	// handshake message.
 	tlsHandshakePrefixSize = 4
+	// tlsMaxSessionTicketSize is the maximum size of a NewSessionTicket message
+	// in TLS 1.3. This is the sum of the max sizes of all the fields in the
+	// NewSessionTicket struct specified in
+	// https://tools.ietf.org/html/rfc8446#section-4.6.1.
+	tlsMaxSessionTicketSize = 131338
 )
 
 const (
@@ -129,6 +144,11 @@ const (
 	outBufMaxRecords = 16
 	// outBufMaxSize is the maximum size (in bytes) of the outRecordsBuf buffer.
 	outBufMaxSize = outBufMaxRecords * tlsRecordMaxSize
+	// maxAllowedTickets is the maximum number of session tickets that are
+	// allowed. The number of tickets are limited to ensure that the size of the
+	// ticket queue does not grow indefinitely. S2A also keeps a limit on the
+	// number of tickets that it caches.
+	maxAllowedTickets = 5
 )
 
 // preConstructedKeyUpdateMsg holds the key update message. This is needed as an
@@ -169,6 +189,13 @@ type conn struct {
 	// since Close may be called during a Write, and also because a key update
 	// message may be written during a Read.
 	writeMutex sync.Mutex
+	// handshakeBuf holds handshake messages while they are being processed.
+	handshakeBuf []byte
+	// ticketState is the current processing state of the session tickets.
+	ticketState sessionTicketState
+	// sessionTickets holds the completed session tickets until they are sent to
+	// the handshaker service for processing.
+	sessionTickets [][]byte
 }
 
 // ConnParameters holds the parameters used for creating a new conn object.
@@ -246,6 +273,16 @@ func NewConn(o *ConnParameters) (net.Conn, error) {
 		nextRecord:    unusedBuf,
 		overheadSize:  overheadSize,
 		hsAddr:        o.HSAddr,
+		ticketState:   ticketsNotYetReceived,
+		// Pre-allocate the buffer for one session ticket message and the max
+		// plaintext size. This is the largest size that handshakeBuf will need
+		// to hold. The largest incomplete handshake message is the
+		// [handshake header size] + [max session ticket size] - 1.
+		// Then, tlsRecordMaxPlaintextSize is the maximum size that will be
+		// appended to the handshakeBuf before the handshake message is
+		// completed. Therefore, the buffer size below should be large enough to
+		// buffer any handshake messages.
+		handshakeBuf: make([]byte, 0, tlsHandshakePrefixSize+tlsMaxSessionTicketSize+tlsRecordMaxPlaintextSize-1),
 	}
 	return s2aConn, nil
 }
@@ -311,65 +348,27 @@ func (p *conn) Read(b []byte) (n int, err error) {
 		// for processing.
 		switch msgType {
 		case applicationData:
-			// Do nothing if the type is application data.
+			if len(p.handshakeBuf) > 0 {
+				return 0, errors.New("application data received while processing fragmented handshake messages")
+			}
+			if p.ticketState == receivingTickets {
+				p.ticketState = notReceivingTickets
+				// TODO: send tickets to handshaker
+			}
 		case alert:
-			if len(p.pendingApplicationData) != tlsAlertSize {
-				return 0, errors.New("invalid alert message size")
+			if err = p.handleAlertMessage(); err != nil {
+				return 0, err
 			}
-			if p.pendingApplicationData[1] == byte(closeNotify) {
-				if err = p.Conn.Close(); err != nil {
-					return 0, err
-				}
-			}
-			// Clear the body of the alert message.
-			p.pendingApplicationData = p.pendingApplicationData[:0]
-			// TODO: add support for more alert types.
 			return 0, nil
 		case handshake:
-			handshakeMsgType := p.pendingApplicationData[0]
-			if handshakeMsgType == tlsHandshakeKeyUpdatePrefix {
-				msgLen := bigEndianInt24(p.pendingApplicationData[tlsHandshakeMsgTypeSize : tlsHandshakeMsgTypeSize+tlsHandshakeLengthSize])
-				if msgLen != tlsHandshakeKeyUpdateMsgSize {
-					return 0, errors.New("invalid handshake key update message length")
-				}
-				keyUpdateRequest := p.pendingApplicationData[tlsHandshakeMsgTypeSize+tlsHandshakeLengthSize]
-				if keyUpdateRequest != byte(updateNotRequested) &&
-					keyUpdateRequest != byte(updateRequested) {
-					return 0, errors.New("invalid handshake key update message")
-				}
-				if err = p.inConn.UpdateKey(); err != nil {
-					return 0, err
-				}
-				// Send a key update message back to the peer if requested.
-				if keyUpdateRequest == byte(updateRequested) {
-					p.writeMutex.Lock()
-					defer p.writeMutex.Unlock()
-					n, err := p.writeTLSRecord(preConstructedKeyUpdateMsg, byte(handshake))
-					if err != nil {
-						return 0, err
-					}
-					if n != tlsHandshakePrefixSize+tlsHandshakeKeyUpdateMsgSize {
-						return 0, errors.New("key update request message wrote less bytes than expected")
-					}
-					if err = p.outConn.UpdateKey(); err != nil {
-						return 0, err
-					}
-				}
-				// Clear the body of the key update message.
-				p.pendingApplicationData = p.pendingApplicationData[:0]
-				return 0, nil
-			} else if handshakeMsgType == tlsHandshakeNewSessionTicket {
-				// TODO: implement this later.
-				grpclog.Infof("Session ticket was received")
-				p.pendingApplicationData = p.pendingApplicationData[:0]
-				return 0, nil
+			if err = p.handleHandshakeMessage(); err != nil {
+				return 0, err
 			}
-			return 0, errors.New("unknown handshake message type")
+			return 0, nil
 		default:
 			return 0, errors.New("unknown record type")
 		}
 	}
-
 	// Write as much application data as possible to b, the output buffer.
 	n = copy(b, p.pendingApplicationData)
 	p.pendingApplicationData = p.pendingApplicationData[n:]
@@ -584,14 +583,127 @@ func splitAndValidateHeader(record []byte) (header, payload []byte, err error) {
 	return header, payload, nil
 }
 
+// handleAlertMessage handles an alert message.
+func (p *conn) handleAlertMessage() error {
+	if len(p.pendingApplicationData) != tlsAlertSize {
+		return errors.New("invalid alert message size")
+	}
+	if p.pendingApplicationData[1] == byte(closeNotify) {
+		if err := p.Conn.Close(); err != nil {
+			return err
+		}
+	}
+	// Clear the body of the alert message.
+	p.pendingApplicationData = p.pendingApplicationData[:0]
+	// TODO: add support for more alert types.
+	return nil
+}
+
+// parseHandshakeHeader parses a handshake message from the handshake buffer.
+// It returns the message type, the message length, the message, and a flag
+// indicating whether the handshake message has been fully parsed. i.e. whether
+// the entire handshake message was in the handshake buffer.
+func (p *conn) parseHandshakeMsg() (msgType byte, msgLen uint32, msg []byte, ok bool) {
+	// Handle the case where the 4 byte handshake header is fragmented.
+	if len(p.handshakeBuf) < tlsHandshakePrefixSize {
+		return 0, 0, nil, false
+	}
+	msgType = p.handshakeBuf[0]
+	msgLen = bigEndianInt24(p.handshakeBuf[tlsHandshakeMsgTypeSize : tlsHandshakeMsgTypeSize+tlsHandshakeLengthSize])
+	if msgLen > uint32(len(p.handshakeBuf)-tlsHandshakePrefixSize) {
+		return 0, 0, nil, false
+	}
+	msg = p.handshakeBuf[tlsHandshakePrefixSize : tlsHandshakePrefixSize+msgLen]
+	p.handshakeBuf = p.handshakeBuf[tlsHandshakePrefixSize+msgLen:]
+	return msgType, msgLen, msg, true
+}
+
+// handleHandshakeMessage handles a handshake message. Note that the first
+// complete handshake message from the handshake buffer is removed, if it
+// exists.
+func (p *conn) handleHandshakeMessage() error {
+	// Copy the pending application data to the handshake buffer. At this point,
+	// we are guaranteed that the pending application data contains only parts
+	// of a handshake message.
+	p.handshakeBuf = append(p.handshakeBuf, p.pendingApplicationData...)
+	p.pendingApplicationData = p.pendingApplicationData[:0]
+	// Several handshake messages may be coalesced into a single record.
+	// Continue reading them until the handshake buffer is empty.
+	for len(p.handshakeBuf) > 0 {
+		handshakeMsgType, msgLen, msg, ok := p.parseHandshakeMsg()
+		if !ok {
+			// The handshake could not be fully parsed, so read in another
+			// record and try again later.
+			break
+		}
+		switch handshakeMsgType {
+		case tlsHandshakeKeyUpdateType:
+			if msgLen != tlsHandshakeKeyUpdateMsgSize {
+				return errors.New("invalid handshake key update message length")
+			}
+			if len(p.handshakeBuf) != 0 {
+				return errors.New("key update message must be the last message of a handshake record")
+			}
+			if err := p.handleKeyUpdateMsg(msg); err != nil {
+				return err
+			}
+		case tlsHandshakeNewSessionTicketType:
+			// Ignore tickets that are received after a batch of tickets has
+			// been sent to S2A.
+			if p.ticketState == notReceivingTickets {
+				continue
+			}
+			if p.ticketState == ticketsNotYetReceived {
+				p.ticketState = receivingTickets
+			}
+			p.sessionTickets = append(p.sessionTickets, msg)
+			if len(p.sessionTickets) == maxAllowedTickets {
+				p.ticketState = notReceivingTickets
+				// TODO: send tickets to handshaker
+			}
+		default:
+			return errors.New("unknown handshake message type")
+		}
+	}
+	return nil
+}
+
 func buildKeyUpdateRequest() []byte {
 	b := make([]byte, tlsHandshakePrefixSize+tlsHandshakeKeyUpdateMsgSize)
-	b[0] = tlsHandshakeKeyUpdatePrefix
+	b[0] = tlsHandshakeKeyUpdateType
 	b[1] = 0
 	b[2] = 0
 	b[3] = tlsHandshakeKeyUpdateMsgSize
 	b[4] = byte(updateNotRequested)
 	return b
+}
+
+// handleKeyUpdateMsg handles a key update message.
+func (p *conn) handleKeyUpdateMsg(msg []byte) error {
+	keyUpdateRequest := msg[0]
+	if keyUpdateRequest != byte(updateNotRequested) &&
+		keyUpdateRequest != byte(updateRequested) {
+		return errors.New("invalid handshake key update message")
+	}
+	if err := p.inConn.UpdateKey(); err != nil {
+		return err
+	}
+	// Send a key update message back to the peer if requested.
+	if keyUpdateRequest == byte(updateRequested) {
+		p.writeMutex.Lock()
+		defer p.writeMutex.Unlock()
+		n, err := p.writeTLSRecord(preConstructedKeyUpdateMsg, byte(handshake))
+		if err != nil {
+			return err
+		}
+		if n != tlsHandshakePrefixSize+tlsHandshakeKeyUpdateMsgSize {
+			return errors.New("key update request message wrote less bytes than expected")
+		}
+		if err = p.outConn.UpdateKey(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // bidEndianInt24 converts the given byte buffer of at least size 3 and

--- a/security/s2a/internal/record/record_test.go
+++ b/security/s2a/internal/record/record_test.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc/security/s2a/internal/record/internal/aeadcrypter/testutil"
 )
 
+var fakeConnEOFError = errors.New("fakeConn is out of bounds")
+
 // fakeConn is a fake implementation of the net.Conn interface used for testing.
 type fakeConn struct {
 	net.Conn
@@ -45,8 +47,10 @@ type fakeConn struct {
 // Read returns part of the `in` buffer in sequential order each time it is
 // called.
 func (c *fakeConn) Read(b []byte) (n int, err error) {
+	if c.bufCount >= len(c.buf) {
+		return 0, fakeConnEOFError
+	}
 	n = copy(b, c.buf[c.bufCount])
-
 	if n < len(c.buf[c.bufCount]) {
 		c.buf[c.bufCount] = c.buf[c.bufCount][n:]
 	} else {
@@ -1162,35 +1166,192 @@ func TestConnReadKeyUpdate(t *testing.T) {
 	}
 }
 
+// buildSessionTicket builds a new session ticket with the given bytes.
+func buildSessionTicket(msg []byte) []byte {
+	b := make([]byte, tlsHandshakePrefixSize+len(msg))
+	b[0] = tlsHandshakeNewSessionTicketType
+	v := len(msg)
+	b[1] = byte(v >> 16)
+	b[2] = byte(v >> 8)
+	b[3] = byte(v)
+	copy(b[4:], msg)
+	return b
+}
+
 func TestConnNewSessionTicket(t *testing.T) {
 	for _, tc := range []struct {
-		desc            string
-		ciphersuite     s2apb.Ciphersuite
-		trafficSecret   []byte
-		completedRecord []byte
+		desc              string
+		ciphersuite       s2apb.Ciphersuite
+		trafficSecret     []byte
+		completedRecords  [][]byte
+		outPlaintexts     [][]byte
+		finalTicketState  sessionTicketState
+		outSessionTickets [][]byte
 	}{
+		// All the session tickets below are []byte{0}. This is not a valid
+		// ticket, but is sufficient for testing since the the client does not
+		// care about the actual value of the ticket.
 		{
-			desc:            "AES-128-GCM-SHA256 new session ticket",
-			ciphersuite:     s2apb.Ciphersuite_AES_128_GCM_SHA256,
-			trafficSecret:   testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-			completedRecord: testutil.Dehex("1703030016c7d6d72499478b3d80281cae5b7c1a3e5cd553aae716"),
+			desc:          "AES-128-GCM-SHA256 new session ticket",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("1703030016c7d6d72499478b3d80281cae5b7c1a3e5cd553aae716"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
 		},
 		{
-			desc:            "AES-256-GCM-SHA384 new session ticket",
-			ciphersuite:     s2apb.Ciphersuite_AES_256_GCM_SHA384,
-			trafficSecret:   testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-			completedRecord: testutil.Dehex("170303001611dddd6fc4869be0e1c12a5a29db1aa2e5814e5894e5"),
+			desc:          "AES-256-GCM-SHA384 new session ticket",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("170303001611dddd6fc4869be0e1c12a5a29db1aa2e5814e5894e5"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
 		},
 		{
-			desc:            "CHACHA20-POLY1305-SHA256 new session ticket",
-			ciphersuite:     s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
-			trafficSecret:   testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
-			completedRecord: testutil.Dehex("1703030016fc75cc914510008c6B45bb46b1f030921006c3556882"),
+			desc:          "CHACHA20-POLY1305-SHA256 new session ticket",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("1703030016fc75cc914510008c6B45bb46b1f030921006c3556882"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
 		},
+		{
+			desc:          "AES-128-GCM-SHA256 new session ticket followed by application data",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("1703030016c7d6d72499478b3d80281cae5b7c1a3e5cd553aae716"),
+				testutil.Dehex("170303001ad7853afd6d7ceaabab950a0b6707905d2b908894871c7c62021f"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+				[]byte("789123456"),
+			},
+			finalTicketState: notReceivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
+		},
+		{
+			desc:          "AES-256-GCM-SHA384 new session ticket followed by application data",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("170303001611dddd6fc4869be0e1c12a5a29db1aa2e5814e5894e5"),
+				testutil.Dehex("170303001a832a5fd271b6442e74bc02111a8e8b52a74b14dd3eca8598b293"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+				[]byte("789123456"),
+			},
+			finalTicketState: notReceivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
+		},
+		{
+			desc:          "CHACHA20-POLY1305-SHA256 new session ticket followed by application data",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("1703030016fc75cc914510008c6B45bb46b1f030921006c3556882"),
+				testutil.Dehex("170303001a0cedeb922170c110c172262542c67916b78fa0d1c1261709cd00"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+				[]byte("789123456"),
+			},
+			finalTicketState: notReceivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
+		},
+		{
+			desc:          "AES-128-GCM-SHA256 ticket, application data, then another ticket",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("1703030016c7d6d72499478b3d80281cae5b7c1a3e5cd553aae716"),
+				testutil.Dehex("170303001ad7853afd6d7ceaabab950a0b6707905d2b908894871c7c62021f"),
+				testutil.Dehex("17030300169c4fb23ec187cec7a8443ae3cd6f45e9dca53023e952"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+				[]byte("789123456"),
+				[]byte(""),
+			},
+			finalTicketState: notReceivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
+		},
+		{
+			desc:          "AES-256-GCM-SHA384 ticket, application data, then another ticket",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("170303001611dddd6fc4869be0e1c12a5a29db1aa2e5814e5894e5"),
+				testutil.Dehex("170303001a832a5fd271b6442e74bc02111a8e8b52a74b14dd3eca8598b293"),
+				testutil.Dehex("1703030016a5f3bdfc4ab1cb73dca49bc86a7fde6396e83d9eb6ac"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+				[]byte("789123456"),
+				[]byte(""),
+			},
+			finalTicketState: notReceivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
+		},
+		{
+			desc:          "CHACHA20-POLY1305-SHA256 ticket, application data, then another ticket",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			completedRecords: [][]byte{
+				testutil.Dehex("1703030016fc75cc914510008c6B45bb46b1f030921006c3556882"),
+				testutil.Dehex("170303001a0cedeb922170c110c172262542c67916b78fa0d1c1261709cd00"),
+				testutil.Dehex("1703030016a1726a73d83b83e97018b7d4b9d33ec9528d7f10e8f2"),
+			},
+			outPlaintexts: [][]byte{
+				[]byte(""),
+				[]byte("789123456"),
+				[]byte(""),
+			},
+			finalTicketState: notReceivingTickets,
+			outSessionTickets: [][]byte{
+				{0},
+			},
+		},
+		// TODO(rnkim): Add test cases for handshake key update messages.
+		// Specifically, fragmented handshake messages and multiple handshake
+		// handshake messages in a single record (which should produce an
+		// error).
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			c, err := NewConn(&ConnParameters{
-				NetConn:          &fakeConn{buf: [][]byte{tc.completedRecord}},
+				NetConn:          &fakeConn{buf: tc.completedRecords},
 				Ciphersuite:      tc.ciphersuite,
 				TLSVersion:       s2apb.TLSVersion_TLS1_3,
 				InTrafficSecret:  tc.trafficSecret,
@@ -1199,19 +1360,284 @@ func TestConnNewSessionTicket(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewConn() failed: %v", err)
 			}
-			plaintext := make([]byte, tlsRecordMaxPlaintextSize)
-			n, err := c.Read(plaintext)
+			for _, outPlaintext := range tc.outPlaintexts {
+				plaintext := make([]byte, tlsRecordMaxPlaintextSize)
+				n, err := c.Read(plaintext)
+				if err != nil {
+					t.Fatalf("c.Read(plaintext) failed: %v", err)
+				}
+				plaintext = plaintext[:n]
+				if got, want := plaintext, outPlaintext; !bytes.Equal(got, want) {
+					t.Errorf("c.Read(plaintext) = %v, want %v", got, want)
+				}
+				if got, want := len(c.(*conn).pendingApplicationData), 0; got != want {
+					t.Errorf("len(c.(*conn).pendingApplicationData) = %v, want %v", got, want)
+				}
+			}
+			newConn := c.(*conn)
+			if got, want := newConn.ticketState, tc.finalTicketState; got != want {
+				t.Errorf("newConn.ticketState = %v, want %v", got, want)
+			}
+			if got, want := newConn.handshakeBuf, make([]byte, 0); !bytes.Equal(got, want) {
+				t.Errorf("newConn.handshakeBuf = %v, want %v", got, want)
+			}
+			if got, want := newConn.sessionTickets, tc.outSessionTickets; !cmp.Equal(got, want) {
+				t.Errorf("newConn.sessionTickets = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestConnNewSessionTicketWithTicketBuilder(t *testing.T) {
+	for _, tc := range []struct {
+		desc              string
+		ciphersuite       s2apb.Ciphersuite
+		trafficSecret     []byte
+		sessionTickets    [][]byte
+		finalTicketState  sessionTicketState
+		outSessionTickets [][]byte
+	}{
+		{
+			desc:          "AES-128-GCM-SHA256 consecutive tickets",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket([]byte("abc")),
+				buildSessionTicket([]byte("abc")),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "AES-256-GCM-SHA384 consecutive tickets",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket([]byte("abc")),
+				buildSessionTicket([]byte("abc")),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "CHACHA20-POLY1305-SHA256 consecutive tickets",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket([]byte("abc")),
+				buildSessionTicket([]byte("abc")),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "AES-128-GCM-SHA256 multiple tickets in one record",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				append(buildSessionTicket([]byte("abc")), buildSessionTicket([]byte("abc"))...),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "AES-256-GCM-SHA384 multiple tickets in one record",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				append(buildSessionTicket([]byte("abc")), buildSessionTicket([]byte("abc"))...),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "CHACHA20-POLY1305-SHA256 multiple tickets in one record",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				append(buildSessionTicket([]byte("abc")), buildSessionTicket([]byte("abc"))...),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "AES-128-GCM-SHA256 fragmented tickets",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				append(buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize/2)), buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize))...),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				make([]byte, tlsRecordMaxPlaintextSize/2),
+				make([]byte, tlsRecordMaxPlaintextSize),
+			},
+		},
+		{
+			desc:          "AES-256-GCM-SHA384 fragmented tickets",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				append(buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize/2)), buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize))...),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				make([]byte, tlsRecordMaxPlaintextSize/2),
+				make([]byte, tlsRecordMaxPlaintextSize),
+			},
+		},
+		{
+			desc:          "CHACHA20-POLY1305-SHA256 fragmented tickets",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				append(buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize/2)), buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize))...),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				make([]byte, tlsRecordMaxPlaintextSize/2),
+				make([]byte, tlsRecordMaxPlaintextSize),
+			},
+		},
+		{
+			desc:          "AES-128-GCM-SHA256 large ticket",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize*2)),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				make([]byte, tlsRecordMaxPlaintextSize*2),
+			},
+		},
+		{
+			desc:          "AES-256-GCM-SHA384 large ticket",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize*2)),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				make([]byte, tlsRecordMaxPlaintextSize*2),
+			},
+		},
+		{
+			desc:          "CHACHA20-POLY1305-SHA256 large ticket",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket(make([]byte, tlsRecordMaxPlaintextSize*2)),
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				make([]byte, tlsRecordMaxPlaintextSize*2),
+			},
+		},
+		{
+			desc:          "AES-128-GCM-SHA256 split in header",
+			ciphersuite:   s2apb.Ciphersuite_AES_128_GCM_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket([]byte("abc"))[:2],
+				buildSessionTicket([]byte("abc"))[2:],
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "AES-256-GCM-SHA384 split in header",
+			ciphersuite:   s2apb.Ciphersuite_AES_256_GCM_SHA384,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket([]byte("abc"))[:2],
+				buildSessionTicket([]byte("abc"))[2:],
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+			},
+		},
+		{
+			desc:          "CHACHA20-POLY1305-SHA256 split in header",
+			ciphersuite:   s2apb.Ciphersuite_CHACHA20_POLY1305_SHA256,
+			trafficSecret: testutil.Dehex("6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b6b"),
+			sessionTickets: [][]byte{
+				buildSessionTicket([]byte("abc"))[:2],
+				buildSessionTicket([]byte("abc"))[2:],
+			},
+			finalTicketState: receivingTickets,
+			outSessionTickets: [][]byte{
+				[]byte("abc"),
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fc := &fakeConn{}
+			netConn, err := NewConn(&ConnParameters{
+				NetConn:          fc,
+				Ciphersuite:      tc.ciphersuite,
+				TLSVersion:       s2apb.TLSVersion_TLS1_3,
+				InTrafficSecret:  tc.trafficSecret,
+				OutTrafficSecret: tc.trafficSecret,
+			})
 			if err != nil {
-				t.Fatalf("c.Read(plaintext) failed: %v", err)
+				t.Fatalf("NewConn() failed: %v", err)
 			}
-			if got, want := n, 0; got != want {
-				t.Errorf("c.Read(plaintext) = %v, want %v", got, want)
+			c := netConn.(*conn)
+			for _, sessionTicket := range tc.sessionTickets {
+				_, err = c.writeTLSRecord(sessionTicket, byte(handshake))
+				if err != nil {
+					t.Fatal("c.writeTLSRecord(sessionTicket, byte(handshake)) failed")
+				}
 			}
-			if got, want := plaintext, make([]byte, tlsRecordMaxPlaintextSize); !bytes.Equal(got, want) {
-				t.Errorf("c.Read(plaintext) modified plaintext")
+			fc.buf = fc.additionalBuf
+			// Read until an EOF error occurs.
+			for {
+				plaintext := make([]byte, tlsRecordMaxPlaintextSize)
+				n, err := c.Read(plaintext)
+				if err != nil {
+					if err == fakeConnEOFError {
+						break
+					}
+					t.Fatalf("c.Read(plaintext) failed: %v", err)
+				}
+				if got, want := n, 0; got != want {
+					t.Errorf("c.Read(plaintext) = %v, want %v,", got, want)
+				}
+				if got, want := len(c.pendingApplicationData), 0; got != want {
+					t.Errorf("len(c.(*conn).pendingApplicationData) = %v, want %v", got, want)
+				}
 			}
-			if got, want := len(c.(*conn).pendingApplicationData), 0; got != want {
-				t.Errorf("len(c.(*conn).pendingApplicationData) = %v, want %v", got, want)
+			if got, want := c.ticketState, tc.finalTicketState; got != want {
+				t.Errorf("newConn.ticketState = %v, want %v", got, want)
+			}
+			if got, want := c.handshakeBuf, make([]byte, 0); !bytes.Equal(got, want) {
+				t.Errorf("newConn.handshakeBuf = %v, want %v", got, want)
+			}
+			if got, want := c.sessionTickets, tc.outSessionTickets; !cmp.Equal(got, want) {
+				t.Errorf("newConn.sessionTickets = %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
Added resumption handling to the S2A client. While adding support for resumption handling, I also refactored some of the code in the `Read` implementation to break up the function into smaller, easier to understand parts. This was necessary since the handshake message handling was getting very large.

Currently, key updates and session tickets can be coalesced into a single record. I haven't added any tests for this case yet, since we don't know if this should be supported or not.

The current tests verify the following:
1) Consecutive tickets in separate records
2) Multiple tickets in the same record
3) Large tickets fragmented across records
4) Consecutive tickets fragmented across records
5) Tickets that are fragmented in the handshake header (This should also work for fragmented key updates as well)
6) Receiving a ticket, application data, and then another ticket. (The second ticket is successfully ignored)

Currently, only the ticket processing has been added. What remains to be added is the communication with the S2A handshaker service upon receiving all the tickets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/67)
<!-- Reviewable:end -->
