### PR TITLE
Add support for sending session tickets to S2A

### DIFF
--- a/security/s2a/internal/handshaker/handshaker.go
+++ b/security/s2a/internal/handshaker/handshaker.go
@@ -239,6 +239,8 @@ func (h *s2aHandshaker) setUpSession(req *s2apb.SessionReq) (net.Conn, *s2apb.Se
 		InSequence:       result.GetState().GetInSequence(),
 		OutSequence:      result.GetState().GetOutSequence(),
 		HSAddr:           h.hsAddr,
+		ConnectionID:     result.GetState().GetConnectionId(),
+		LocalIdentity:    result.GetLocalIdentity(),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/security/s2a/internal/record/record.go
+++ b/security/s2a/internal/record/record.go
@@ -180,8 +180,6 @@ type conn struct {
 	// is computed as overheadSize = header size + record type byte + tag size.
 	// Note that there is no padding by zeros in the overhead calculation.
 	overheadSize int
-	// hsAddr stores the address of the S2A handshaker service.
-	hsAddr string
 	// readMutex guards against concurrent calls to Read. This is required since
 	// Close may be called during a Read.
 	readMutex sync.Mutex
@@ -196,6 +194,8 @@ type conn struct {
 	// sessionTickets holds the completed session tickets until they are sent to
 	// the handshaker service for processing.
 	sessionTickets [][]byte
+	// ticketSender sends session tickets to the S2A handshaker service.
+	ticketSender s2aTicketSender
 }
 
 // ConnParameters holds the parameters used for creating a new conn object.
@@ -228,6 +228,12 @@ type ConnParameters struct {
 	// HSAddr stores the address of the S2A handshaker service. This parameter
 	// is optional. If not provided, then TLS resumption is disabled.
 	HSAddr string
+	// ConnectionId is the connection identifier that was created and sent by
+	// S2A at the end of a handshake.
+	ConnectionID uint64
+	// LocalIdentity is the local identity that was used by S2A during session
+	// setup and included in the session result.
+	LocalIdentity *s2apb.Identity
 }
 
 func NewConn(o *ConnParameters) (net.Conn, error) {
@@ -272,7 +278,6 @@ func NewConn(o *ConnParameters) (net.Conn, error) {
 		outRecordsBuf: make([]byte, tlsRecordMaxSize),
 		nextRecord:    unusedBuf,
 		overheadSize:  overheadSize,
-		hsAddr:        o.HSAddr,
 		ticketState:   ticketsNotYetReceived,
 		// Pre-allocate the buffer for one session ticket message and the max
 		// plaintext size. This is the largest size that handshakeBuf will need
@@ -283,6 +288,11 @@ func NewConn(o *ConnParameters) (net.Conn, error) {
 		// completed. Therefore, the buffer size below should be large enough to
 		// buffer any handshake messages.
 		handshakeBuf: make([]byte, 0, tlsHandshakePrefixSize+tlsMaxSessionTicketSize+tlsRecordMaxPlaintextSize-1),
+		ticketSender: &ticketSender{
+			hsAddr:        o.HSAddr,
+			connectionID:  o.ConnectionID,
+			localIdentity: o.LocalIdentity,
+		},
 	}
 	return s2aConn, nil
 }
@@ -353,7 +363,7 @@ func (p *conn) Read(b []byte) (n int, err error) {
 			}
 			if p.ticketState == receivingTickets {
 				p.ticketState = notReceivingTickets
-				// TODO: send tickets to handshaker
+				p.ticketSender.sendTicketsToS2A(p.sessionTickets)
 			}
 		case alert:
 			return 0, p.handleAlertMessage()
@@ -656,7 +666,7 @@ func (p *conn) handleHandshakeMessage() error {
 			p.sessionTickets = append(p.sessionTickets, msg)
 			if len(p.sessionTickets) == maxAllowedTickets {
 				p.ticketState = notReceivingTickets
-				// TODO: send tickets to handshaker
+				p.ticketSender.sendTicketsToS2A(p.sessionTickets)
 			}
 		default:
 			return errors.New("unknown handshake message type")

--- a/security/s2a/internal/record/ticketsender.go
+++ b/security/s2a/internal/record/ticketsender.go
@@ -1,0 +1,118 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package record
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/security/s2a/internal/handshaker/service"
+	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
+)
+
+// sessionTimeout is the timeout for creating a session with the S2A handshaker
+// service.
+const sessionTimeout = time.Second * 5
+
+// s2aTicketSender sends session tickets to the S2A handshaker service.
+type s2aTicketSender interface {
+	// sendTicketsToS2A sends the given session tickets to the S2A handshaker
+	// service.
+	sendTicketsToS2A(sessionTickets [][]byte)
+}
+
+// ticketStream is the stream used to send and receive session information.
+type ticketStream interface {
+	Send(*s2apb.SessionReq) error
+	Recv() (*s2apb.SessionResp, error)
+}
+
+type ticketSender struct {
+	// hsAddr stores the address of the S2A handshaker service.
+	hsAddr string
+	// connectionID is the connection identifier that was created and sent by
+	// S2A at the end of a handshake.
+	connectionID uint64
+	// localIdentity is the local identity that was used by S2A during session
+	// setup and included in the session result.
+	localIdentity *s2apb.Identity
+}
+
+// sendTicketsToS2A sends the given sessionTickets to the S2A handshaker
+// service. This is done asynchronously and writes to the error logs if an error
+// occurs.
+func (t *ticketSender) sendTicketsToS2A(sessionTickets [][]byte) {
+	// Note that the goroutine is in the function rather than at the caller
+	// because the fake ticket sender used for testing must run synchronously
+	// so that the session tickets can be accessed from it after the tests have
+	// been run.
+	go func() {
+		if err := func() error {
+			hsConn, err := service.Dial(t.hsAddr)
+			if err != nil {
+				return err
+			}
+			client := s2apb.NewS2AServiceClient(hsConn)
+			ctx, cancel := context.WithTimeout(context.Background(), sessionTimeout)
+			defer cancel()
+			session, err := client.SetUpSession(ctx)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := session.CloseSend(); err != nil {
+					grpclog.Error(err)
+				}
+			}()
+			return t.writeTicketsToStream(session, sessionTickets)
+		}(); err != nil {
+			grpclog.Errorf("failed to send resumption tickets to S2A with identity: %v, %v",
+				t.localIdentity, err)
+		}
+	}()
+}
+
+// writeTicketsToStream writes the given session tickets to the given stream.
+func (t *ticketSender) writeTicketsToStream(stream ticketStream, sessionTickets [][]byte) error {
+	if err := stream.Send(
+		&s2apb.SessionReq{
+			ReqOneof: &s2apb.SessionReq_ResumptionTicket{
+				ResumptionTicket: &s2apb.ResumptionTicketReq{
+					InBytes:       sessionTickets,
+					ConnectionId:  t.connectionID,
+					LocalIdentity: t.localIdentity,
+				},
+			},
+		},
+	); err != nil {
+		return err
+	}
+	sessionResp, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if sessionResp.GetStatus().GetCode() != uint32(codes.OK) {
+		return fmt.Errorf("s2a session ticket response had error status: %v, %v",
+			sessionResp.GetStatus().GetCode(), sessionResp.GetStatus().GetDetails())
+	}
+	return nil
+}

--- a/security/s2a/internal/record/ticketsender_test.go
+++ b/security/s2a/internal/record/ticketsender_test.go
@@ -1,0 +1,93 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package record
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	s2apb "google.golang.org/grpc/security/s2a/internal/proto"
+)
+
+type fakeStream struct {
+	// returnInvalid is a flag indicating whether the return status of Recv is
+	// OK or not.
+	returnInvalid bool
+	// returnRecvErr is a flag indicating whether an error should be returned by
+	// Recv.
+	returnRecvErr bool
+}
+
+func (fs *fakeStream) Send(req *s2apb.SessionReq) error {
+	if len(req.GetResumptionTicket().InBytes) == 0 {
+		return errors.New("fakeStream Send received an empty InBytes")
+	}
+	if req.GetResumptionTicket().ConnectionId == 0 {
+		return errors.New("fakeStream Send received a 0 ConnectionId")
+	}
+	if req.GetResumptionTicket().LocalIdentity == nil {
+		return errors.New("fakeStream Send received an empty LocalIdentity")
+	}
+	return nil
+}
+
+func (fs *fakeStream) Recv() (*s2apb.SessionResp, error) {
+	if fs.returnRecvErr {
+		return nil, errors.New("fakeStream Recv error")
+	}
+	if fs.returnInvalid {
+		return &s2apb.SessionResp{
+			Status: &s2apb.SessionStatus{Code: uint32(codes.InvalidArgument)},
+		}, nil
+	}
+	return &s2apb.SessionResp{
+		Status: &s2apb.SessionStatus{Code: uint32(codes.OK)},
+	}, nil
+}
+
+func TestWriteTicketsToStream(t *testing.T) {
+	for _, tc := range []struct {
+		returnInvalid   bool
+		returnRecvError bool
+	}{
+		{
+			// Both flags are set to false.
+		},
+		{
+			returnInvalid: true,
+		},
+		{
+			returnRecvError: true,
+		},
+	} {
+		sender := ticketSender{
+			connectionID: 1,
+			localIdentity: &s2apb.Identity{
+				IdentityOneof: &s2apb.Identity_SpiffeId{
+					SpiffeId: "test_spiffe_id",
+				},
+			},
+		}
+		fs := &fakeStream{returnInvalid: tc.returnInvalid, returnRecvErr: tc.returnRecvError}
+		if got, want := sender.writeTicketsToStream(fs, make([][]byte, 1)) == nil, !tc.returnRecvError && !tc.returnInvalid; got != want {
+			t.Errorf("sender.writeTicketsToStream(%v, _) = (err=nil) = %v, want %v", fs, got, want)
+		}
+	}
+}


### PR DESCRIPTION
This PR is a followup to #67 .

Added support for sending session tickets to S2A once we reach the limit on the number of session tickets or stop receiving session tickets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matthewstevenson88/grpc-go/69)
<!-- Reviewable:end -->
